### PR TITLE
Docdb prod remove records

### DIFF
--- a/environment/postInstall
+++ b/environment/postInstall
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-pip install --no-cache-dir aind-codeocean-api==0.2.4
-pip install --no-cache-dir aind-data-access-api[secrets,docdb]==0.6.1
+pip install --no-cache-dir aind-data-access-api[secrets,docdb]==0.8.0
 pip install --no-cache-dir pytz==2023.3
-pip install --no-cache-dir aind-data-schema==0.15.12
+pip install --no-cache-dir aind-data-schema==0.26.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,8 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    "aind-codeocean-api==0.2.4",
-    "aind-data-access-api[secrets,docdb]==0.6.1",
-    "aind-data-schema==0.15.12",
+    "aind-data-access-api[secrets,docdb]==0.8.0",
+    "aind-data-schema==0.26.5",
     "pytz==2023.3"
 ]
 

--- a/tests/test_job_runner.py
+++ b/tests/test_job_runner.py
@@ -352,10 +352,20 @@ class TestJobRunner(unittest.TestCase):
         "aind_data_access_api.document_db.MetadataDbClient"
         ".upsert_list_of_records"
     )
+    @patch(
+        "aind_data_access_api.document_db.MetadataDbClient"
+        ".delete_many_records"
+    )
+    @patch(
+        "aind_data_access_api.document_db.MetadataDbClient"
+        ".retrieve_data_asset_records"
+    )
     @patch("boto3.client")
     def test_run_job(
         self,
         mock_s3_client: MagicMock,
+        mock_doc_store_retrieve_records: MagicMock,
+        mock_doc_store_delete: MagicMock,
         mock_doc_store_upsert: MagicMock,
         mock_codeocean_client: MagicMock,
     ):
@@ -383,6 +393,14 @@ class TestJobRunner(unittest.TestCase):
         mock_doc_store_upsert.assert_called_once_with(
             [expected_data_asset_record]
         )
+
+        mock_doc_store_retrieve_records.assert_called_once_with(
+            filter_query={},
+            projection={'_id': 1, '_name': 1, '_created': 1, '_location': 1},
+            paginate=False
+        )
+
+        mock_doc_store_delete.assert_called_once_with([])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #31 

- Compares the ids in docdb and the ids in code ocean index
- Removes the records in docdb if they are not found in code ocean index (can happen if people delete data assets)
- Updates aind-data-schema in dependencies
- Updates aind-data-access-api in dependencies
- Uses the version of aind-codeocean-api that is bundled with aind-data-access-api