### PR TITLE
feat: copy core schema jsons in s3 and keep in sync with docdb

### DIFF
--- a/src/aind_data_asset_indexer/__init__.py
+++ b/src/aind_data_asset_indexer/__init__.py
@@ -1,3 +1,3 @@
 """Package"""
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/src/aind_data_asset_indexer/__init__.py
+++ b/src/aind_data_asset_indexer/__init__.py
@@ -1,2 +1,3 @@
 """Package"""
+
 __version__ = "0.4.1"

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -127,8 +127,8 @@ class AindIndexBucketJob:
                         prefix=f"{prefix}/original_metadata",
                     )
                     if copy_exists_in_s3:
-                        # if /original_metadata exists, then we only need to overwrite
-                        # the top-level jsons of updated core_fields
+                        # if /original_metadata exists, then we only need to
+                        # overwrite the top-level jsons of updated core_fields
                         sync_core_json_files(
                             metadata_json=record_as_json_str,
                             bucket=s3_bucket,
@@ -137,8 +137,9 @@ class AindIndexBucketJob:
                             log_flag=True,
                         )
                     else:
-                        # if /original_metadata does not exist, then we need to copy
-                        # and overwrite all the core jsons using the new metadata.nd.json
+                        # if /original_metadata does not exist, then we need
+                        # to copy and overwrite all the core jsons using the
+                        # new metadata.nd.json
                         copy_then_overwrite_core_json_files(
                             metadata_json=record_as_json_str,
                             bucket=s3_bucket,
@@ -223,6 +224,16 @@ class AindIndexBucketJob:
         location_to_id_map: Dict[str, str],
     ):
         """
+        Processes a prefix in S3.
+        # If metadata record exists in S3 and DocDB, do nothing.
+        # If record is in S3 but not DocDb, then copy it to DocDb if the
+        # location in the metadata record matches the actual location.
+        # Otherwise, log a warning.
+        # If record does not exist in both DocDB and S3, build a new metadata
+        # file and save it to S3 (assume Lambda function will save to DocDB).
+        # In both cases above, we also copy the original core json files to a
+        # subfolder and ensure the top level core jsons are in sync with the
+        # metadata.nd.json in S3.
 
         Parameters
         ----------
@@ -306,7 +317,7 @@ class AindIndexBucketJob:
         else:  # metadata.nd.json file does not exist in S3. Create a new one.
             # Build a new metadata file, save it to S3 and save it to DocDb.
             # Also copy the original core json files to a subfolder and then
-            # overwrite the top-level jsons with the new fields from metadata.nd.json.
+            # overwrite them with the new fields from metadata.nd.json.
             new_metadata_contents = build_metadata_record_from_prefix(
                 bucket=bucket,
                 prefix=s3_prefix,

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -146,6 +146,9 @@ class AindIndexBucketJob:
                             prefix=prefix,
                             s3_client=s3_client,
                             log_flag=True,
+                            copy_original_md_subdir=(
+                                self.job_settings.copy_original_md_subdir
+                            ),
                         )
                     logging.info(
                         f"Uploading metadata record for: "
@@ -297,6 +300,9 @@ class AindIndexBucketJob:
                             prefix=s3_prefix,
                             s3_client=s3_client,
                             log_flag=True,
+                            copy_original_md_subdir=(
+                                self.job_settings.copy_original_md_subdir
+                            ),
                         )
                     else:
                         logging.warning(
@@ -331,6 +337,9 @@ class AindIndexBucketJob:
                     prefix=s3_prefix,
                     s3_client=s3_client,
                     log_flag=True,
+                    copy_original_md_subdir=(
+                        self.job_settings.copy_original_md_subdir
+                    ),
                 )
                 logging.info(f"Uploading metadata record for: {location}")
                 s3_response = upload_metadata_json_str_to_s3(

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -23,6 +23,7 @@ from aind_data_asset_indexer.utils import (
     download_json_file_from_s3,
     get_dict_of_file_info,
     get_s3_bucket_and_prefix,
+    get_s3_location,
     is_record_location_valid,
     iterate_through_top_level,
     paginate_docdb,
@@ -203,8 +204,9 @@ class AindIndexBucketJob:
 
         """
         # Check if metadata record exists
-        stripped_prefix = s3_prefix.strip("/")
-        location = f"s3://{self.job_settings.s3_bucket}/{stripped_prefix}"
+        location = get_s3_location(
+            bucket=self.job_settings.s3_bucket, prefix=s3_prefix
+        )
         if location_to_id_map.get(location) is not None:
             record_id = location_to_id_map.get(location)
         else:
@@ -247,8 +249,7 @@ class AindIndexBucketJob:
                         logging.warning(
                             f"Location field in record "
                             f"{json_contents.get('location')} does not match "
-                            f"actual location of record "
-                            f"s3://{self.job_settings.s3_bucket}/{s3_prefix}!"
+                            f"actual location of record {location}!"
                         )
                 else:
                     logging.warning(
@@ -281,8 +282,7 @@ class AindIndexBucketJob:
                 # then next index job will pick it up.
             else:
                 logging.warning(
-                    f"Was unable to build metadata record for: "
-                    f"s3://{self.job_settings.s3_bucket}/{stripped_prefix}"
+                    f"Was unable to build metadata record for: {location}"
                 )
 
     def _dask_task_to_process_prefix_list(self, prefix_list: List[str]):

--- a/src/aind_data_asset_indexer/models.py
+++ b/src/aind_data_asset_indexer/models.py
@@ -21,6 +21,12 @@ class IndexJobSettings(BaseSettings):
             "set to None, then all records will be processed."
         ),
     )
+    copy_original_md_subdir: str = Field(
+        default="original_metadata",
+        description=(
+            "Subdirectory to copy original core schema json files to."
+        ),
+    )
 
     @classmethod
     def from_param_store(cls, param_store_name: str):

--- a/src/aind_data_asset_indexer/models.py
+++ b/src/aind_data_asset_indexer/models.py
@@ -21,14 +21,6 @@ class IndexJobSettings(BaseSettings):
             "set to None, then all records will be processed."
         ),
     )
-    metadata_nd_overwrite: bool = Field(
-        default=False,
-        description=(
-            "If set to True, will ignore the metadata.nd.json file and use "
-            "the core schemas to build a new one. If set to False, then use"
-            "the metadata.nd.json file if it exists in S3."
-        ),
-    )
 
     @classmethod
     def from_param_store(cls, param_store_name: str):

--- a/src/aind_data_asset_indexer/populate_aind_buckets.py
+++ b/src/aind_data_asset_indexer/populate_aind_buckets.py
@@ -17,7 +17,9 @@ logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
 
 
 class PopulateAindBucketsJob:
-    """Job to populate a list of aind buckets with metadata.nd.json files."""
+    """Job to populate a list of aind buckets with metadata json files
+    and copy original core schema jsons to a subfolder.
+    """
 
     def __init__(self, job_settings: PopulateAindBucketsJobSettings):
         """Class constructor."""

--- a/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
+++ b/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
@@ -62,6 +62,7 @@ class AindPopulateMetadataJsonJob:
             bucket=self.job_settings.s3_bucket,
             metadata_nd_overwrite=self.job_settings.metadata_nd_overwrite,
         )
+        # TODO: check behavior if metadata_nd_overwrite is False (md_record still exists)
         if md_record is not None:
             bucket = self.job_settings.s3_bucket
             md_record_json = json.loads(md_record)
@@ -84,7 +85,10 @@ class AindPopulateMetadataJsonJob:
                     logging.info(response)
                     # Overwrite core schema fields from metadata.nd.json to the core json files.
                     core_field = core_schema_filename.replace(".json", "")
-                    if core_field in md_record_json:
+                    if (
+                        core_field in md_record_json
+                        and md_record_json[core_field] is not None
+                    ):
                         core_json = md_record_json[core_field]
                         core_json_str = json.dumps(core_json)
                         logging.info(
@@ -99,6 +103,7 @@ class AindPopulateMetadataJsonJob:
                         )
                         logging.info(response)
                     else:
+                        # TODO: verify how this is handled
                         logging.warning(
                             f"{core_field} not found in metadata.nd.json for {prefix} but "
                             f"s3://{bucket}/{source} exists. Skipping overwrite."
@@ -108,6 +113,7 @@ class AindPopulateMetadataJsonJob:
                         f"s3://{bucket}/{source} does not exist. Skipping copy."
                     )
             # Upload metadata.nd.json to s3
+            # TODO: do we also want to copy original metadata.nd.json file to /original_metadata?
             logging.info(
                 f"Uploading metadata record for s3://{bucket}/{prefix}"
             )

--- a/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
+++ b/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
@@ -32,6 +32,10 @@ class AindPopulateMetadataJsonJob:
     3) If the name is a data asset name, then it will look inside the prefix
     4) It will create a metadata.nd.json by using any of the core json files
     it finds. Any existing metadata.nd.json will be overwritten.
+    5.1) The contents of any existing core json files will be copied to
+    /original_metadata/{core_schema}.{date_stamp}.json.
+    5.2) The core json files will be overwritten with the new fields from
+    metadata.nd.json or deleted if they are not found in metadata.nd.json.
     """
 
     def __init__(self, job_settings: IndexJobSettings):
@@ -41,6 +45,9 @@ class AindPopulateMetadataJsonJob:
     def _process_prefix(self, prefix: str, s3_client: S3Client):
         """
         For a given prefix, build a metadata record and upload it to S3.
+        Original core json files will be first copied to a subfolder,
+        and then overwritten with the new fields from metadata.nd.json,
+        or deleted if the new field is None.
         Parameters
         ----------
         prefix : str

--- a/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
+++ b/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
@@ -72,6 +72,9 @@ class AindPopulateMetadataJsonJob:
                 prefix=prefix,
                 s3_client=s3_client,
                 log_flag=True,
+                copy_original_md_subdir=(
+                    self.job_settings.copy_original_md_subdir
+                ),
             )
             logging.info(f"Uploading metadata record for: {location}")
             # noinspection PyTypeChecker

--- a/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
+++ b/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
@@ -15,6 +15,7 @@ from aind_data_asset_indexer.models import IndexJobSettings
 from aind_data_asset_indexer.utils import (
     build_metadata_record_from_prefix,
     copy_then_overwrite_core_json_files,
+    get_s3_location,
     iterate_through_top_level,
     upload_metadata_json_str_to_s3,
 )
@@ -51,6 +52,7 @@ class AindPopulateMetadataJsonJob:
 
         """
         bucket = self.job_settings.s3_bucket
+        location = get_s3_location(bucket=bucket, prefix=prefix)
         md_record = build_metadata_record_from_prefix(
             prefix=prefix,
             s3_client=s3_client,
@@ -64,10 +66,7 @@ class AindPopulateMetadataJsonJob:
                 s3_client=s3_client,
                 log_flag=True,
             )
-            # Upload metadata.nd.json to s3
-            logging.info(
-                f"Uploading metadata record for s3://{bucket}/{prefix}"
-            )
+            logging.info(f"Uploading metadata record for: {location}")
             # noinspection PyTypeChecker
             response = upload_metadata_json_str_to_s3(
                 metadata_json=md_record,
@@ -78,7 +77,7 @@ class AindPopulateMetadataJsonJob:
             logging.info(response)
         else:
             logging.warning(
-                f"Unable to build metadata record for: s3://{bucket}/{prefix}!"
+                f"Unable to build metadata record for: {location}!"
             )
 
     def _dask_task_to_process_prefix_list(

--- a/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
+++ b/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
@@ -57,7 +57,7 @@ class AindPopulateMetadataJsonJob:
             bucket=bucket,
         )
         if md_record is not None:
-            responses = copy_then_overwrite_core_json_files(
+            copy_then_overwrite_core_json_files(
                 metadata_json=md_record,
                 bucket=bucket,
                 prefix=prefix,

--- a/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
+++ b/src/aind_data_asset_indexer/populate_s3_with_metadata_files.py
@@ -86,8 +86,7 @@ class AindPopulateMetadataJsonJob:
                         core_json = md_record_json[core_field]
                         core_json_str = json.dumps(core_json)
                         logging.info(
-                            f"Overwriting s3://{bucket}/{source} with new "
-                            f"{core_field} from metadata.nd.json"
+                            f"Uploading new {core_field} to s3://{bucket}/{source}"
                         )
                         response = upload_json_str_to_s3(
                             bucket=bucket,
@@ -97,11 +96,16 @@ class AindPopulateMetadataJsonJob:
                         )
                         logging.info(response)
                     else:
-                        # TODO: verify how this is handled
+                        # If a core json was corrupt, it would not exist in the metadata.nd.json
+                        # Since a copy has been made already, we can delete it from the top level
                         logging.warning(
                             f"{core_field} not found in metadata.nd.json for {prefix} but "
-                            f"s3://{bucket}/{source} exists! Skipping overwrite."
+                            f"s3://{bucket}/{source} exists! Deleting."
                         )
+                        response = s3_client.delete_object(
+                            Bucket=bucket, Key=source
+                        )
+                        logging.info(response)
                 else:
                     logging.info(
                         f"s3://{bucket}/{source} does not exist. Skipping copy."

--- a/src/aind_data_asset_indexer/utils.py
+++ b/src/aind_data_asset_indexer/utils.py
@@ -3,7 +3,6 @@
 import hashlib
 import json
 import logging
-from datetime import datetime
 from json.decoder import JSONDecodeError
 from typing import Dict, Iterator, List, Optional
 from urllib.parse import urlparse
@@ -147,7 +146,10 @@ def create_core_schema_object_keys_map(
     for source_key, file_info in s3_file_responses.items():
         file_name = source_key.split("/")[-1]
         source = source_key
-        date_stamp = file_info["last_modified"].strftime("%Y%m%d")
+        if file_info is not None:
+            date_stamp = file_info["last_modified"].strftime("%Y%m%d")
+        else:
+            date_stamp = "unknown"
         target = create_object_key(
             prefix=target_prefix,
             filename=file_name.replace(".json", f".{date_stamp}.json"),
@@ -624,7 +626,12 @@ def copy_then_overwrite_core_json_files(
             ),
             log_flag=log_flag,
         )
-    object_keys = create_core_schema_object_keys_map(prefix, tgt_copy_prefix)
+    object_keys = create_core_schema_object_keys_map(
+        s3_client=s3_client,
+        bucket=bucket,
+        prefix=prefix,
+        target_prefix=tgt_copy_prefix,
+    )
     for file_name, key_mapping in object_keys.items():
         source = key_mapping["source"]
         target = key_mapping["target"]

--- a/src/aind_data_asset_indexer/utils.py
+++ b/src/aind_data_asset_indexer/utils.py
@@ -18,8 +18,6 @@ from mypy_boto3_s3.type_defs import (
 )
 from pymongo import MongoClient
 
-COPY_ORIGINAL_MD_SUBDIR = "original_metadata"
-
 # TODO: This would be better if it was available in aind-data-schema
 core_schema_file_names = [
     s.default_filename()
@@ -572,6 +570,7 @@ def copy_then_overwrite_core_json_files(
     bucket: str,
     prefix: str,
     s3_client: S3Client,
+    copy_original_md_subdir: str = "original_metadata",
     log_flag: bool = False,
 ) -> None:
     """
@@ -591,6 +590,9 @@ def copy_then_overwrite_core_json_files(
         The S3 client object.
     log_flag: bool
         Flag indicating whether to log operations. Default is False.
+    copy_original_md_subdir : str
+        Subdirectory to copy original core schema json files to.
+        Default is 'original_metadata'.
 
     Returns
     -------
@@ -598,7 +600,8 @@ def copy_then_overwrite_core_json_files(
 
     """
     md_record_json = json.loads(metadata_json)
-    tgt_copy_prefix = create_object_key(prefix, COPY_ORIGINAL_MD_SUBDIR)
+    tgt_copy_subdir = copy_original_md_subdir.strip("/")
+    tgt_copy_prefix = create_object_key(prefix, tgt_copy_subdir)
     if does_s3_prefix_exist(
         s3_client=s3_client, bucket=bucket, prefix=tgt_copy_prefix
     ):

--- a/src/aind_data_asset_indexer/utils.py
+++ b/src/aind_data_asset_indexer/utils.py
@@ -396,11 +396,11 @@ def is_dict_corrupt(input_dict: dict) -> bool:
       False otherwise.
 
     """
-    for key in input_dict.keys():
+    for key, value in input_dict.items():
         if "$" in key or "." in key:
             return True
-        elif isinstance(input_dict[key], dict):
-            if is_dict_corrupt(input_dict[key]):
+        elif isinstance(value, dict):
+            if is_dict_corrupt(value):
                 return True
     return False
 
@@ -492,7 +492,7 @@ def build_metadata_record_from_prefix(
         metadata_dict = Metadata.model_construct(**metadata_dict).model_dump_json(
             warnings=False, by_alias=True
         )
-    except Exception as e:
+    except Exception:
         metadata_dict = None
     return metadata_dict
 

--- a/src/aind_data_asset_indexer/utils.py
+++ b/src/aind_data_asset_indexer/utils.py
@@ -400,7 +400,8 @@ def is_dict_corrupt(input_dict: dict) -> bool:
         if "$" in key or "." in key:
             return True
         elif isinstance(input_dict[key], dict):
-            return is_dict_corrupt(input_dict[key])
+            if is_dict_corrupt(input_dict[key]):
+                return True
     return False
 
 

--- a/tests/resources/utils/example_list_objects_response.json
+++ b/tests/resources/utils/example_list_objects_response.json
@@ -1,0 +1,33 @@
+{
+  "ResponseMetadata": {
+     "RequestId": "RequestId",
+     "HostId": "HostId",
+     "HTTPStatusCode": 200,
+     "HTTPHeaders": {
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id",
+        "date": "Thu, 23 May 2024 21:54:26 GMT",
+        "x-amz-bucket-region": "us-west-2",
+        "content-type": "application/xml",
+        "transfer-encoding": "chunked",
+        "server": "AmazonS3"
+     },
+     "RetryAttempts": 0
+  },
+  "IsTruncated": true,
+  "Contents": [
+     {
+        "Key": "prefix/original_metadata/data_description.20240522.json",
+        "LastModified": "2024-05-23 01:17:29+00:00",
+        "ETag": "\"1145037da6d39eda39a68fc262eb9e2d\"",
+        "Size": 1385,
+        "StorageClass": "STANDARD"
+     }
+  ],
+  "Name": "bucket",
+  "Prefix": "prefix/original_metadata/",
+  "MaxKeys": 1,
+  "EncodingType": "url",
+  "KeyCount": 1,
+  "NextContinuationToken": "NextContinuationToken"
+}

--- a/tests/resources/utils/example_list_objects_response_false.json
+++ b/tests/resources/utils/example_list_objects_response_false.json
@@ -1,0 +1,23 @@
+{
+   "ResponseMetadata": {
+      "RequestId": "RequestId",
+      "HostId": "HostId",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+         "x-amz-id-2": "x-amz-id-2",
+         "x-amz-request-id": "x-amz-request-id",
+         "date": "Thu, 23 May 2024 22:48:26 GMT",
+         "x-amz-bucket-region": "us-west-2",
+         "content-type": "application/xml",
+         "transfer-encoding": "chunked",
+         "server": "AmazonS3"
+      },
+      "RetryAttempts": 0
+   },
+   "IsTruncated": false,
+   "Name": "bucket",
+   "Prefix": "prefix/original_metadata/",
+   "MaxKeys": 1,
+   "EncodingType": "url",
+   "KeyCount": 0
+}

--- a/tests/resources/utils/example_list_objects_response_unexpected.json
+++ b/tests/resources/utils/example_list_objects_response_unexpected.json
@@ -1,0 +1,40 @@
+{
+  "ResponseMetadata": {
+     "RequestId": "RequestId",
+     "HostId": "HostId",
+     "HTTPStatusCode": 200,
+     "HTTPHeaders": {
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id",
+        "date": "Thu, 23 May 2024 21:54:26 GMT",
+        "x-amz-bucket-region": "us-west-2",
+        "content-type": "application/xml",
+        "transfer-encoding": "chunked",
+        "server": "AmazonS3"
+     },
+     "RetryAttempts": 0
+  },
+  "IsTruncated": true,
+  "Contents": [
+     {
+        "Key": "prefix/original_metadata/data_description.20240522.json",
+        "LastModified": "2024-05-23 01:17:29+00:00",
+        "ETag": "ETag1",
+        "Size": 1385,
+        "StorageClass": "STANDARD"
+     },
+     {
+         "Key": "prefix/original_metadata/subject.20240522.json",
+         "LastModified": "2024-05-23 01:17:29+00:00",
+         "ETag": "ETag2",
+         "Size": 1385,
+         "StorageClass": "STANDARD"
+      }
+  ],
+  "Name": "bucket",
+  "Prefix": "prefix/original_metadata/",
+  "MaxKeys": 1,
+  "EncodingType": "url",
+  "KeyCount": 1,
+  "NextContinuationToken": "NextContinuationToken"
+}

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -161,7 +161,10 @@ class TestAindIndexBucketJob(unittest.TestCase):
         "aind_data_asset_indexer.aind_bucket_indexer."
         "upload_metadata_json_str_to_s3"
     )
-    @patch("aind_data_asset_indexer.aind_bucket_indexer.copy_then_overwrite_core_json_files")
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "copy_then_overwrite_core_json_files"
+    )
     @patch("aind_data_asset_indexer.aind_bucket_indexer.sync_core_json_files")
     @patch("aind_data_asset_indexer.aind_bucket_indexer.does_s3_prefix_exist")
     @patch("aind_data_asset_indexer.aind_bucket_indexer.get_dict_of_file_info")

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -49,6 +49,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             doc_db_password="docdb_password",
             doc_db_db_name="dbname",
             doc_db_collection_name="collection_name",
+            copy_original_md_subdir="original_metadata",
         )
         cls.basic_job_configs = basic_job_configs
         cls.basic_job = AindIndexBucketJob(job_settings=basic_job_configs)
@@ -295,6 +296,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             prefix=expected_prefix,
             s3_client=mock_s3_client,
             log_flag=True,
+            copy_original_md_subdir="original_metadata",
         )
 
         mock_log_info.assert_has_calls(
@@ -472,6 +474,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             prefix=expected_prefix,
             s3_client=mock_s3_client,
             log_flag=True,
+            copy_original_md_subdir="original_metadata",
         )
         mock_upload_metadata_json_str_to_s3.assert_called_once_with(
             metadata_json=json.dumps(self.example_md_record),
@@ -599,6 +602,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             prefix="ecephys_642478_2023-01-17_13-56-29",
             s3_client=mock_s3_client,
             log_flag=True,
+            copy_original_md_subdir="original_metadata",
         )
         mock_upload_metadata_json_str_to_s3.assert_not_called()
 

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -42,7 +42,6 @@ class TestAindIndexBucketJob(unittest.TestCase):
 
         basic_job_configs = AindIndexBucketJobSettings(
             s3_bucket="aind-ephys-data-dev-u5u0i5",
-            metadata_nd_overwrite=False,
             n_partitions=2,
             doc_db_host="docdb_host",
             doc_db_port=123,
@@ -289,9 +288,9 @@ class TestAindIndexBucketJob(unittest.TestCase):
             location_to_id_map=location_to_id_map,
         )
         mock_log_warn.assert_called_once_with(
-            "Was unable to build metadata record for: "
+            "Unable to build metadata record for: "
             f"s3://{self.basic_job.job_settings.s3_bucket}/"
-            f"ecephys_642478_2023-01-17_13-56-29"
+            f"ecephys_642478_2023-01-17_13-56-29!"
         )
 
     @patch(
@@ -375,9 +374,9 @@ class TestAindIndexBucketJob(unittest.TestCase):
             location_to_id_map=location_to_id_map,
         )
         mock_log_warn.assert_called_once_with(
-            "Unable to download file from S3!"
+            f"Unable to download file from S3 for:"
             f" s3://{self.basic_job.job_settings.s3_bucket}/"
-            f"ecephys_642478_2023-01-17_13-56-29/metadata.nd.json"
+            f"ecephys_642478_2023-01-17_13-56-29/metadata.nd.json!"
         )
 
     @patch(

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -259,6 +259,14 @@ class TestAindIndexBucketJob(unittest.TestCase):
 
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer."
+        "upload_metadata_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "copy_then_overwrite_core_json_files"
+    )
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
         "build_metadata_record_from_prefix"
     )
     @patch("aind_data_asset_indexer.aind_bucket_indexer.does_s3_object_exist")
@@ -272,6 +280,8 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_docdb_client: MagicMock,
         mock_does_s3_object_exist: MagicMock,
         mock_build_metadata_record_from_prefix: MagicMock,
+        mock_copy_then_overwrite_core_json_files: MagicMock,
+        mock_upload_metadata_json_str_to_s3: MagicMock,
     ):
         """Tests _process_prefix method when there is no record in DocDb,
         there is no metadata.nd.json file in S3, and the
@@ -292,10 +302,16 @@ class TestAindIndexBucketJob(unittest.TestCase):
             f"s3://{self.basic_job.job_settings.s3_bucket}/"
             f"ecephys_642478_2023-01-17_13-56-29!"
         )
+        mock_copy_then_overwrite_core_json_files.assert_not_called()
+        mock_upload_metadata_json_str_to_s3.assert_not_called()
 
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer."
         "upload_metadata_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "copy_then_overwrite_core_json_files"
     )
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer."
@@ -312,6 +328,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_docdb_client: MagicMock,
         mock_does_s3_object_exist: MagicMock,
         mock_build_metadata_record_from_prefix: MagicMock,
+        mock_copy_then_overwrite_core_json_files: MagicMock,
         mock_upload_metadata_json_str_to_s3: MagicMock,
     ):
         """Tests _process_prefix method when there is no record in DocDb,
@@ -336,6 +353,13 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_log_info.assert_called_once_with(
             self.example_put_object_response1
         )
+        mock_copy_then_overwrite_core_json_files.assert_called_once_with(
+            metadata_json=json.dumps(self.example_md_record),
+            bucket=self.basic_job.job_settings.s3_bucket,
+            prefix="ecephys_642478_2023-01-17_13-56-29",
+            s3_client=mock_s3_client,
+            log_flag=True,
+        )
         mock_upload_metadata_json_str_to_s3.assert_called_once_with(
             metadata_json=json.dumps(self.example_md_record),
             bucket=self.basic_job.job_settings.s3_bucket,
@@ -343,6 +367,14 @@ class TestAindIndexBucketJob(unittest.TestCase):
             s3_client=mock_s3_client,
         )
 
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "upload_metadata_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "copy_then_overwrite_core_json_files"
+    )
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer."
         "download_json_file_from_s3"
@@ -358,9 +390,11 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_docdb_client: MagicMock,
         mock_does_s3_object_exist: MagicMock,
         mock_download_json_file_from_s3: MagicMock,
+        mock_copy_then_overwrite_core_json_files: MagicMock,
+        mock_upload_metadata_json_str_to_s3: MagicMock,
     ):
         """Tests _process_prefix method when there is no record in DocDb,
-        there is, there is metadata.nd.json file in S3, but the file can't
+        there is metadata.nd.json file in S3, but the file can't
         be serialized to json."""
 
         mock_does_s3_object_exist.return_value = True
@@ -378,7 +412,17 @@ class TestAindIndexBucketJob(unittest.TestCase):
             f" s3://{self.basic_job.job_settings.s3_bucket}/"
             f"ecephys_642478_2023-01-17_13-56-29/metadata.nd.json!"
         )
+        mock_copy_then_overwrite_core_json_files.assert_not_called()
+        mock_upload_metadata_json_str_to_s3.assert_not_called()
 
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "upload_metadata_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "copy_then_overwrite_core_json_files"
+    )
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer."
         "download_json_file_from_s3"
@@ -394,6 +438,8 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_docdb_client: MagicMock,
         mock_does_s3_object_exist: MagicMock,
         mock_download_json_file_from_s3: MagicMock,
+        mock_copy_then_overwrite_core_json_files: MagicMock,
+        mock_upload_metadata_json_str_to_s3: MagicMock,
     ):
         """Tests _process_prefix method when there is no record in DocDb,
         there is and there is metadata.nd.json file in S3, and the file can
@@ -434,7 +480,23 @@ class TestAindIndexBucketJob(unittest.TestCase):
                 "updatedExisting": False,
             }
         )
+        mock_copy_then_overwrite_core_json_files.assert_called_once_with(
+            metadata_json=json.dumps(self.example_md_record),
+            bucket=self.basic_job.job_settings.s3_bucket,
+            prefix="ecephys_642478_2023-01-17_13-56-29",
+            s3_client=mock_s3_client,
+            log_flag=True,
+        )
+        mock_upload_metadata_json_str_to_s3.assert_not_called()
 
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "upload_metadata_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "copy_then_overwrite_core_json_files"
+    )
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer."
         "download_json_file_from_s3"
@@ -450,6 +512,8 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_docdb_client: MagicMock,
         mock_does_s3_object_exist: MagicMock,
         mock_download_json_file_from_s3: MagicMock,
+        mock_copy_then_overwrite_core_json_files: MagicMock,
+        mock_upload_metadata_json_str_to_s3: MagicMock,
     ):
         """Tests _process_prefix method when there is no record in DocDb,
         there is and there is metadata.nd.json file in S3, and the file can
@@ -478,6 +542,8 @@ class TestAindIndexBucketJob(unittest.TestCase):
             location_to_id_map=location_to_id_map,
         )
         mock_collection.assert_not_called()
+        mock_copy_then_overwrite_core_json_files.assert_not_called()
+        mock_upload_metadata_json_str_to_s3.assert_not_called()
         mock_log_warn.assert_called_once_with(
             "Location field in record "
             "s3://aind-ephys-data-dev-u5u0i5/"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,7 +20,6 @@ class TestIndexJobSettings(unittest.TestCase):
         job_settings = IndexJobSettings(s3_bucket="some_bucket")
         self.assertEqual("some_bucket", job_settings.s3_bucket)
         self.assertEqual(20, job_settings.n_partitions)
-        self.assertFalse(job_settings.metadata_nd_overwrite)
         self.assertIsNone(job_settings.lookback_days)
 
     @patch("boto3.client")
@@ -33,8 +32,7 @@ class TestIndexJobSettings(unittest.TestCase):
                 "Value": (
                     '{"s3_bucket":"some_bucket",'
                     '"n_partitions":5,'
-                    '"lookback_days":10,'
-                    '"metadata_nd_overwrite":true}'
+                    '"lookback_days":10}'
                 ),
                 "Version": 1,
                 "LastModifiedDate": datetime(
@@ -64,7 +62,6 @@ class TestIndexJobSettings(unittest.TestCase):
             s3_bucket="some_bucket",
             n_partitions=5,
             lookback_days=10,
-            metadata_nd_overwrite=True,
         )
         self.assertEqual(expected_job_settings, job_settings)
 
@@ -85,7 +82,6 @@ class TestAindIndexBucketJobSettings(unittest.TestCase):
         )
         self.assertEqual("some_bucket", job_settings.s3_bucket)
         self.assertEqual(20, job_settings.n_partitions)
-        self.assertFalse(job_settings.metadata_nd_overwrite)
         self.assertIsNone(job_settings.lookback_days)
         self.assertEqual("some_docdb_host", job_settings.doc_db_host)
         self.assertEqual(12345, job_settings.doc_db_port)
@@ -111,7 +107,6 @@ class TestPopulateAindBucketsJobSettings(unittest.TestCase):
         self.assertIsNone(job_settings.s3_bucket)
         self.assertEqual(["bucket1", "bucket2"], job_settings.s3_buckets)
         self.assertEqual(20, job_settings.n_partitions)
-        self.assertFalse(job_settings.metadata_nd_overwrite)
         self.assertIsNone(job_settings.lookback_days)
 
 
@@ -132,7 +127,6 @@ class TestAindIndexBucketsJobSettings(unittest.TestCase):
         self.assertIsNone(job_settings.s3_bucket)
         self.assertEqual(["bucket1", "bucket2"], job_settings.s3_buckets)
         self.assertEqual(20, job_settings.n_partitions)
-        self.assertFalse(job_settings.metadata_nd_overwrite)
         self.assertIsNone(job_settings.lookback_days)
         self.assertEqual("some_docdb_host", job_settings.doc_db_host)
         self.assertEqual(12345, job_settings.doc_db_port)

--- a/tests/test_populate_s3_with_metadata_files.py
+++ b/tests/test_populate_s3_with_metadata_files.py
@@ -82,6 +82,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             prefix=expected_prefix,
             s3_client=mock_s3_client,
             log_flag=True,
+            copy_original_md_subdir="original_metadata",
         )
         mock_upload_record.assert_called_once_with(
             bucket=expected_bucket,

--- a/tests/test_populate_s3_with_metadata_files.py
+++ b/tests/test_populate_s3_with_metadata_files.py
@@ -45,11 +45,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
     )
     @patch(
         "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "upload_json_str_to_s3"
-    )
-    @patch(
-        "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "does_s3_object_exist"
+        "copy_then_overwrite_core_json_files"
     )
     @patch(
         "aind_data_asset_indexer.populate_s3_with_metadata_files."
@@ -64,25 +60,14 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
         mock_log_warn: MagicMock,
         mock_s3_client: MagicMock,
         mock_build_record: MagicMock,
-        mock_does_s3_object_exist: MagicMock,
-        mock_upload_core_record: MagicMock,
+        mock_copy_then_overwrite_core_json_files: MagicMock,
         mock_upload_metadata_record: MagicMock,
     ):
         """Tests _process_prefix method."""
 
         expected_bucket = "aind-ephys-data-dev-u5u0i5"
         expected_prefix = "ecephys_642478_2023-01-17_13-56-29"
-        expected_date_stamp = datetime.now().strftime("%Y%m%d")
-        # example_md_record only has processing and subject fields
         mock_build_record.return_value = json.dumps(self.example_md_record)
-        def mock_source_files_exist(s3_client, bucket, key):
-            """Mock does_s3_object_exist function."""
-            mock_exist_files = [
-                f"{expected_prefix}/processing.json",
-                f"{expected_prefix}/subject.json",
-            ]
-            return True if key in mock_exist_files else False
-        mock_does_s3_object_exist.side_effect = mock_source_files_exist
         self.basic_job._process_prefix(
             s3_client=mock_s3_client,
             prefix=expected_prefix,
@@ -92,49 +77,16 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             s3_client=mock_s3_client,
             bucket=expected_bucket,
         )
-        # assert that the original core jsons were copied
-        mock_does_s3_object_exist.assert_called()
-        mock_s3_client.copy_object.assert_has_calls(
-            [
-                call(
-                    Bucket=expected_bucket,
-                    CopySource={
-                        "Bucket": expected_bucket,
-                        "Key": f"{expected_prefix}/processing.json",
-                    },
-                    Key=f"{expected_prefix}/original_metadata/processing.{expected_date_stamp}.json",
-                ),
-                call(
-                    Bucket=expected_bucket,
-                    CopySource={
-                        "Bucket": expected_bucket,
-                        "Key": f"{expected_prefix}/subject.json",
-                    },
-                    Key=f"{expected_prefix}/original_metadata/subject.{expected_date_stamp}.json",
-                ),
-            ]
+        mock_copy_then_overwrite_core_json_files.assert_called_once_with(
+            metadata_json=json.dumps(self.example_md_record),
+            bucket=expected_bucket,
+            prefix=expected_prefix,
+            s3_client=mock_s3_client,
+            log_flag=True,
         )
-        # assert that core jsons were overwritten
-        mock_upload_core_record.assert_has_calls(
-            [
-                call(
-                    bucket=expected_bucket,
-                    object_key=f"{expected_prefix}/processing.json",
-                    json_str=json.dumps(self.example_md_record["processing"]),
-                    s3_client=mock_s3_client,
-                ),
-                call(
-                    bucket=expected_bucket,
-                    object_key=f"{expected_prefix}/subject.json",
-                    json_str=json.dumps(self.example_md_record["subject"]),
-                    s3_client=mock_s3_client,
-                ),
-            ]
-        )
-        # assert that the metadata record was uploaded
         mock_upload_metadata_record.assert_called_once_with(
-            bucket="aind-ephys-data-dev-u5u0i5",
-            prefix="ecephys_642478_2023-01-17_13-56-29",
+            bucket=expected_bucket,
+            prefix=expected_prefix,
             s3_client=mock_s3_client,
             metadata_json=json.dumps(self.example_md_record),
         )
@@ -147,132 +99,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
     )
     @patch(
         "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "upload_json_str_to_s3"
-    )
-    @patch(
-        "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "does_s3_object_exist"
-    )
-    @patch(
-        "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "build_metadata_record_from_prefix"
-    )
-    @patch("boto3.client")
-    @patch("logging.warning")
-    @patch("logging.info")
-    def test_process_prefix_not_none_core_fields_mismatch(
-        self,
-        mock_log_info: MagicMock,
-        mock_log_warn: MagicMock,
-        mock_s3_client: MagicMock,
-        mock_build_record: MagicMock,
-        mock_does_s3_object_exist: MagicMock,
-        mock_upload_core_record: MagicMock,
-        mock_upload_metadata_record: MagicMock,
-    ):
-        """Tests _process_prefix method when an original core json
-        does not exist in generated metadata.nd.json."""
-
-        expected_bucket = "aind-ephys-data-dev-u5u0i5"
-        expected_prefix = "ecephys_642478_2023-01-17_13-56-29"
-        expected_date_stamp = datetime.now().strftime("%Y%m%d")
-        # example_md_record only has processing and subject fields
-        # assume rig.json exists but is corrupt
-        mock_build_record.return_value = json.dumps(self.example_md_record)
-        def mock_source_files_exist(s3_client, bucket, key):
-            """Mock does_s3_object_exist function."""
-            mock_exist_files = [
-                f"{expected_prefix}/processing.json",
-                f"{expected_prefix}/rig.json",
-                f"{expected_prefix}/subject.json",
-            ]
-            return True if key in mock_exist_files else False
-        mock_does_s3_object_exist.side_effect = mock_source_files_exist
-        self.basic_job._process_prefix(
-            s3_client=mock_s3_client,
-            prefix=expected_prefix,
-        )
-        mock_build_record.assert_called_once_with(
-            prefix=expected_prefix,
-            s3_client=mock_s3_client,
-            bucket=expected_bucket,
-        )
-        # assert that the original core jsons were copied, including
-        # corrupt rig.json
-        mock_does_s3_object_exist.assert_called()
-        mock_s3_client.copy_object.assert_has_calls(
-            [
-                call(
-                    Bucket=expected_bucket,
-                    CopySource={
-                        "Bucket": expected_bucket,
-                        "Key": f"{expected_prefix}/processing.json",
-                    },
-                    Key=f"{expected_prefix}/original_metadata/processing.{expected_date_stamp}.json",
-                ),
-                call(
-                    Bucket=expected_bucket,
-                    CopySource={
-                        "Bucket": expected_bucket,
-                        "Key": f"{expected_prefix}/rig.json",
-                    },
-                    Key=f"{expected_prefix}/original_metadata/rig.{expected_date_stamp}.json",
-                ),
-                call(
-                    Bucket=expected_bucket,
-                    CopySource={
-                        "Bucket": expected_bucket,
-                        "Key": f"{expected_prefix}/subject.json",
-                    },
-                    Key=f"{expected_prefix}/original_metadata/subject.{expected_date_stamp}.json",
-                ),
-            ]
-        )
-        # assert that only valid core jsons were overwritten
-        mock_upload_core_record.assert_has_calls(
-            [
-                call(
-                    bucket=expected_bucket,
-                    object_key=f"{expected_prefix}/processing.json",
-                    json_str=json.dumps(self.example_md_record["processing"]),
-                    s3_client=mock_s3_client,
-                ),
-                call(
-                    bucket=expected_bucket,
-                    object_key=f"{expected_prefix}/subject.json",
-                    json_str=json.dumps(self.example_md_record["subject"]),
-                    s3_client=mock_s3_client,
-                ),
-            ]
-        )
-        # assert the corrupt core json was deleted
-        mock_log_info.assert_called()
-        mock_log_warn.assert_called_once_with(
-            f"rig not found in metadata.nd.json for {expected_prefix} but "
-            f"s3://{expected_bucket}/{expected_prefix}/rig.json exists! Deleting."
-        )
-        mock_s3_client.delete_object.assert_called_once_with(
-            Bucket=expected_bucket, Key=f"{expected_prefix}/rig.json"
-        )
-        # assert that the metadata record was uploaded
-        mock_upload_metadata_record.assert_called_once_with(
-            bucket="aind-ephys-data-dev-u5u0i5",
-            prefix="ecephys_642478_2023-01-17_13-56-29",
-            s3_client=mock_s3_client,
-            metadata_json=json.dumps(self.example_md_record),
-        )
-
-    @patch(
-        "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "upload_metadata_json_str_to_s3"
-    )
-    @patch(
-        "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "upload_json_str_to_s3"
-    )
-    @patch(
-        "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "does_s3_object_exist"
+        "copy_then_overwrite_core_json_files"
     )
     @patch(
         "aind_data_asset_indexer.populate_s3_with_metadata_files."
@@ -287,8 +114,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
         mock_log_warn: MagicMock,
         mock_s3_client: MagicMock,
         mock_build_record: MagicMock,
-        mock_does_s3_object_exist: MagicMock,
-        mock_upload_core_record: MagicMock,
+        mock_copy_then_overwrite_core_json_files: MagicMock,
         mock_upload_metadata_record: MagicMock,
     ):
         """Tests _process_prefix method when None is returned from
@@ -304,9 +130,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             s3_client=mock_s3_client,
             bucket="aind-ephys-data-dev-u5u0i5",
         )
-        mock_does_s3_object_exist.assert_not_called()
-        mock_s3_client.copy_object.assert_not_called()
-        mock_upload_core_record.assert_not_called()
+        mock_copy_then_overwrite_core_json_files.assert_not_called()
         mock_upload_metadata_record.assert_not_called()
         mock_log_info.assert_not_called()
         mock_log_warn.assert_called_once_with(

--- a/tests/test_populate_s3_with_metadata_files.py
+++ b/tests/test_populate_s3_with_metadata_files.py
@@ -3,7 +3,6 @@
 import json
 import os
 import unittest
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 

--- a/tests/test_populate_s3_with_metadata_files.py
+++ b/tests/test_populate_s3_with_metadata_files.py
@@ -32,7 +32,6 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
         cls.example_md_record = example_md_record
         basic_job_configs = IndexJobSettings(
             s3_bucket="aind-ephys-data-dev-u5u0i5",
-            metadata_nd_overwrite=True,
             n_partitions=2,
         )
         cls.basic_job_configs = basic_job_configs
@@ -92,7 +91,6 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             prefix=expected_prefix,
             s3_client=mock_s3_client,
             bucket=expected_bucket,
-            metadata_nd_overwrite=True,
         )
         # assert that the original core jsons were copied
         mock_does_s3_object_exist.assert_called()
@@ -197,7 +195,6 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             prefix=expected_prefix,
             s3_client=mock_s3_client,
             bucket=expected_bucket,
-            metadata_nd_overwrite=True,
         )
         # assert that the original core jsons were copied, including
         # corrupt rig.json
@@ -251,7 +248,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
         mock_log_info.assert_called()
         mock_log_warn.assert_called_once_with(
             f"rig not found in metadata.nd.json for {expected_prefix} but "
-            f"s3://{expected_bucket}/{expected_prefix}/rig.json exists. Skipping overwrite."
+            f"s3://{expected_bucket}/{expected_prefix}/rig.json exists! Skipping overwrite."
         )
         # assert that the metadata record was uploaded
         mock_upload_metadata_record.assert_called_once_with(
@@ -302,7 +299,6 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             prefix="ecephys_642478_2023-01-17_13-56-29",
             s3_client=mock_s3_client,
             bucket="aind-ephys-data-dev-u5u0i5",
-            metadata_nd_overwrite=True,
         )
         mock_does_s3_object_exist.assert_not_called()
         mock_s3_client.copy_object.assert_not_called()
@@ -310,7 +306,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
         mock_upload_metadata_record.assert_not_called()
         mock_log_info.assert_not_called()
         mock_log_warn.assert_called_once_with(
-            "Metadata record is None for "
+            "Unable to build metadata record for: "
             "s3://aind-ephys-data-dev-u5u0i5/"
             "ecephys_642478_2023-01-17_13-56-29!"
         )

--- a/tests/test_populate_s3_with_metadata_files.py
+++ b/tests/test_populate_s3_with_metadata_files.py
@@ -170,7 +170,8 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
         mock_upload_core_record: MagicMock,
         mock_upload_metadata_record: MagicMock,
     ):
-        """Tests _process_prefix method when original core json is corrupt."""
+        """Tests _process_prefix method when an original core json
+        does not exist in generated metadata.nd.json."""
 
         expected_bucket = "aind-ephys-data-dev-u5u0i5"
         expected_prefix = "ecephys_642478_2023-01-17_13-56-29"
@@ -244,11 +245,14 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
                 ),
             ]
         )
-        # assert that a warning was logged for the corrupt core json
+        # assert the corrupt core json was deleted
         mock_log_info.assert_called()
         mock_log_warn.assert_called_once_with(
             f"rig not found in metadata.nd.json for {expected_prefix} but "
-            f"s3://{expected_bucket}/{expected_prefix}/rig.json exists! Skipping overwrite."
+            f"s3://{expected_bucket}/{expected_prefix}/rig.json exists! Deleting."
+        )
+        mock_s3_client.delete_object.assert_called_once_with(
+            Bucket=expected_bucket, Key=f"{expected_prefix}/rig.json"
         )
         # assert that the metadata record was uploaded
         mock_upload_metadata_record.assert_called_once_with(

--- a/tests/test_populate_s3_with_metadata_files.py
+++ b/tests/test_populate_s3_with_metadata_files.py
@@ -61,7 +61,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
         mock_s3_client: MagicMock,
         mock_build_record: MagicMock,
         mock_copy_then_overwrite_core_json_files: MagicMock,
-        mock_upload_metadata_record: MagicMock,
+        mock_upload_record: MagicMock,
     ):
         """Tests _process_prefix method."""
 
@@ -84,7 +84,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             s3_client=mock_s3_client,
             log_flag=True,
         )
-        mock_upload_metadata_record.assert_called_once_with(
+        mock_upload_record.assert_called_once_with(
             bucket=expected_bucket,
             prefix=expected_prefix,
             s3_client=mock_s3_client,
@@ -115,7 +115,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
         mock_s3_client: MagicMock,
         mock_build_record: MagicMock,
         mock_copy_then_overwrite_core_json_files: MagicMock,
-        mock_upload_metadata_record: MagicMock,
+        mock_upload_record: MagicMock,
     ):
         """Tests _process_prefix method when None is returned from
         build_metadata_record_from_prefix."""
@@ -131,7 +131,7 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             bucket="aind-ephys-data-dev-u5u0i5",
         )
         mock_copy_then_overwrite_core_json_files.assert_not_called()
-        mock_upload_metadata_record.assert_not_called()
+        mock_upload_record.assert_not_called()
         mock_log_info.assert_not_called()
         mock_log_warn.assert_called_once_with(
             "Unable to build metadata record for: "

--- a/tests/test_populate_s3_with_metadata_files.py
+++ b/tests/test_populate_s3_with_metadata_files.py
@@ -3,6 +3,7 @@
 import json
 import os
 import unittest
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -41,53 +42,253 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
 
     @patch(
         "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "build_metadata_record_from_prefix"
+        "upload_metadata_json_str_to_s3"
     )
     @patch(
         "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "upload_metadata_json_str_to_s3"
+        "upload_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "does_s3_object_exist"
+    )
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "build_metadata_record_from_prefix"
     )
     @patch("boto3.client")
+    @patch("logging.warning")
     @patch("logging.info")
     def test_process_prefix_not_none(
         self,
         mock_log_info: MagicMock,
+        mock_log_warn: MagicMock,
         mock_s3_client: MagicMock,
-        mock_upload_record: MagicMock,
         mock_build_record: MagicMock,
+        mock_does_s3_object_exist: MagicMock,
+        mock_upload_core_record: MagicMock,
+        mock_upload_metadata_record: MagicMock,
     ):
         """Tests _process_prefix method."""
 
+        expected_bucket = "aind-ephys-data-dev-u5u0i5"
+        expected_prefix = "ecephys_642478_2023-01-17_13-56-29"
+        expected_date_stamp = datetime.now().strftime("%Y%m%d")
+        # example_md_record only has processing and subject fields
         mock_build_record.return_value = json.dumps(self.example_md_record)
+        def mock_source_files_exist(s3_client, bucket, key):
+            """Mock does_s3_object_exist function."""
+            mock_exist_files = [
+                f"{expected_prefix}/processing.json",
+                f"{expected_prefix}/subject.json",
+            ]
+            return True if key in mock_exist_files else False
+        mock_does_s3_object_exist.side_effect = mock_source_files_exist
         self.basic_job._process_prefix(
             s3_client=mock_s3_client,
-            prefix="ecephys_642478_2023-01-17_13-56-29",
+            prefix=expected_prefix,
         )
-
-        mock_upload_record.assert_called_once_with(
+        mock_build_record.assert_called_once_with(
+            prefix=expected_prefix,
+            s3_client=mock_s3_client,
+            bucket=expected_bucket,
+            metadata_nd_overwrite=True,
+        )
+        # assert that the original core jsons were copied
+        mock_does_s3_object_exist.assert_called()
+        mock_s3_client.copy_object.assert_has_calls(
+            [
+                call(
+                    Bucket=expected_bucket,
+                    CopySource={
+                        "Bucket": expected_bucket,
+                        "Key": f"{expected_prefix}/processing.json",
+                    },
+                    Key=f"{expected_prefix}/original_metadata/processing.{expected_date_stamp}.json",
+                ),
+                call(
+                    Bucket=expected_bucket,
+                    CopySource={
+                        "Bucket": expected_bucket,
+                        "Key": f"{expected_prefix}/subject.json",
+                    },
+                    Key=f"{expected_prefix}/original_metadata/subject.{expected_date_stamp}.json",
+                ),
+            ]
+        )
+        # assert that core jsons were overwritten
+        mock_upload_core_record.assert_has_calls(
+            [
+                call(
+                    bucket=expected_bucket,
+                    object_key=f"{expected_prefix}/processing.json",
+                    json_str=json.dumps(self.example_md_record["processing"]),
+                    s3_client=mock_s3_client,
+                ),
+                call(
+                    bucket=expected_bucket,
+                    object_key=f"{expected_prefix}/subject.json",
+                    json_str=json.dumps(self.example_md_record["subject"]),
+                    s3_client=mock_s3_client,
+                ),
+            ]
+        )
+        # assert that the metadata record was uploaded
+        mock_upload_metadata_record.assert_called_once_with(
             bucket="aind-ephys-data-dev-u5u0i5",
             prefix="ecephys_642478_2023-01-17_13-56-29",
             s3_client=mock_s3_client,
             metadata_json=json.dumps(self.example_md_record),
         )
-        mock_log_info.assert_called_once()
+        mock_log_info.assert_called()
+        mock_log_warn.assert_not_called()
 
-    @patch(
-        "aind_data_asset_indexer.populate_s3_with_metadata_files."
-        "build_metadata_record_from_prefix"
-    )
     @patch(
         "aind_data_asset_indexer.populate_s3_with_metadata_files."
         "upload_metadata_json_str_to_s3"
     )
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "upload_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "does_s3_object_exist"
+    )
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "build_metadata_record_from_prefix"
+    )
     @patch("boto3.client")
     @patch("logging.warning")
-    def test_process_prefix_none(
+    @patch("logging.info")
+    def test_process_prefix_not_none_core_fields_mismatch(
         self,
+        mock_log_info: MagicMock,
         mock_log_warn: MagicMock,
         mock_s3_client: MagicMock,
-        mock_upload_record: MagicMock,
         mock_build_record: MagicMock,
+        mock_does_s3_object_exist: MagicMock,
+        mock_upload_core_record: MagicMock,
+        mock_upload_metadata_record: MagicMock,
+    ):
+        """Tests _process_prefix method when original core json is corrupt."""
+
+        expected_bucket = "aind-ephys-data-dev-u5u0i5"
+        expected_prefix = "ecephys_642478_2023-01-17_13-56-29"
+        expected_date_stamp = datetime.now().strftime("%Y%m%d")
+        # example_md_record only has processing and subject fields
+        # assume rig.json exists but is corrupt
+        mock_build_record.return_value = json.dumps(self.example_md_record)
+        def mock_source_files_exist(s3_client, bucket, key):
+            """Mock does_s3_object_exist function."""
+            mock_exist_files = [
+                f"{expected_prefix}/processing.json",
+                f"{expected_prefix}/rig.json",
+                f"{expected_prefix}/subject.json",
+            ]
+            return True if key in mock_exist_files else False
+        mock_does_s3_object_exist.side_effect = mock_source_files_exist
+        self.basic_job._process_prefix(
+            s3_client=mock_s3_client,
+            prefix=expected_prefix,
+        )
+        mock_build_record.assert_called_once_with(
+            prefix=expected_prefix,
+            s3_client=mock_s3_client,
+            bucket=expected_bucket,
+            metadata_nd_overwrite=True,
+        )
+        # assert that the original core jsons were copied, including
+        # corrupt rig.json
+        mock_does_s3_object_exist.assert_called()
+        mock_s3_client.copy_object.assert_has_calls(
+            [
+                call(
+                    Bucket=expected_bucket,
+                    CopySource={
+                        "Bucket": expected_bucket,
+                        "Key": f"{expected_prefix}/processing.json",
+                    },
+                    Key=f"{expected_prefix}/original_metadata/processing.{expected_date_stamp}.json",
+                ),
+                call(
+                    Bucket=expected_bucket,
+                    CopySource={
+                        "Bucket": expected_bucket,
+                        "Key": f"{expected_prefix}/rig.json",
+                    },
+                    Key=f"{expected_prefix}/original_metadata/rig.{expected_date_stamp}.json",
+                ),
+                call(
+                    Bucket=expected_bucket,
+                    CopySource={
+                        "Bucket": expected_bucket,
+                        "Key": f"{expected_prefix}/subject.json",
+                    },
+                    Key=f"{expected_prefix}/original_metadata/subject.{expected_date_stamp}.json",
+                ),
+            ]
+        )
+        # assert that only valid core jsons were overwritten
+        mock_upload_core_record.assert_has_calls(
+            [
+                call(
+                    bucket=expected_bucket,
+                    object_key=f"{expected_prefix}/processing.json",
+                    json_str=json.dumps(self.example_md_record["processing"]),
+                    s3_client=mock_s3_client,
+                ),
+                call(
+                    bucket=expected_bucket,
+                    object_key=f"{expected_prefix}/subject.json",
+                    json_str=json.dumps(self.example_md_record["subject"]),
+                    s3_client=mock_s3_client,
+                ),
+            ]
+        )
+        # assert that a warning was logged for the corrupt core json
+        mock_log_info.assert_called()
+        mock_log_warn.assert_called_once_with(
+            f"rig not found in metadata.nd.json for {expected_prefix} but "
+            f"s3://{expected_bucket}/{expected_prefix}/rig.json exists. Skipping overwrite."
+        )
+        # assert that the metadata record was uploaded
+        mock_upload_metadata_record.assert_called_once_with(
+            bucket="aind-ephys-data-dev-u5u0i5",
+            prefix="ecephys_642478_2023-01-17_13-56-29",
+            s3_client=mock_s3_client,
+            metadata_json=json.dumps(self.example_md_record),
+        )
+
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "upload_metadata_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "upload_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "does_s3_object_exist"
+    )
+    @patch(
+        "aind_data_asset_indexer.populate_s3_with_metadata_files."
+        "build_metadata_record_from_prefix"
+    )
+    @patch("boto3.client")
+    @patch("logging.warning")
+    @patch("logging.info")
+    def test_process_prefix_none(
+        self,
+        mock_log_info: MagicMock,
+        mock_log_warn: MagicMock,
+        mock_s3_client: MagicMock,
+        mock_build_record: MagicMock,
+        mock_does_s3_object_exist: MagicMock,
+        mock_upload_core_record: MagicMock,
+        mock_upload_metadata_record: MagicMock,
     ):
         """Tests _process_prefix method when None is returned from
         build_metadata_record_from_prefix."""
@@ -97,8 +298,17 @@ class TestAindPopulateMetadataJsonJob(unittest.TestCase):
             s3_client=mock_s3_client,
             prefix="ecephys_642478_2023-01-17_13-56-29",
         )
-
-        mock_upload_record.assert_not_called()
+        mock_build_record.assert_called_once_with(
+            prefix="ecephys_642478_2023-01-17_13-56-29",
+            s3_client=mock_s3_client,
+            bucket="aind-ephys-data-dev-u5u0i5",
+            metadata_nd_overwrite=True,
+        )
+        mock_does_s3_object_exist.assert_not_called()
+        mock_s3_client.copy_object.assert_not_called()
+        mock_upload_core_record.assert_not_called()
+        mock_upload_metadata_record.assert_not_called()
+        mock_log_info.assert_not_called()
         mock_log_warn.assert_called_once_with(
             "Metadata record is None for "
             "s3://aind-ephys-data-dev-u5u0i5/"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,10 +111,13 @@ class TestUtils(unittest.TestCase):
         good_contents = {"a": 1, "b": {"c": 2, "d": 3}}
         bad_contents1 = {"a.1": 1, "b": {"c": 2, "d": 3}}
         bad_contents2 = {"a": 1, "b": {"c": 2, "$d": 3}}
-
+        bad_contents3 = {"a": 1, "b": {"c": 2, "d": 3}, "$e": 4}
+        bad_contents4 = {"a": 1, "b": {"c": {"d": 3}, "$e": 4}}
         self.assertFalse(is_dict_corrupt(good_contents))
         self.assertTrue(is_dict_corrupt(bad_contents1))
         self.assertTrue(is_dict_corrupt(bad_contents2))
+        self.assertTrue(is_dict_corrupt(bad_contents3))
+        self.assertTrue(is_dict_corrupt(bad_contents4))
 
     def test_create_object_key(self):
         """Tests create_object_key"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,7 +125,7 @@ class TestUtils(unittest.TestCase):
 
     @patch("logging.log")
     def test__log_message_true(self, mock_log: MagicMock):
-        """Tests _log_message method with log_flag set to True or not provided"""
+        """Tests _log_message method when log_flag is True or not provided"""
         message = "This is a test message"
         valid_log_levels = [
             logging.DEBUG,
@@ -156,7 +156,7 @@ class TestUtils(unittest.TestCase):
 
     @patch("logging.log")
     def test__log_message_false(self, mock_log: MagicMock):
-        """Tests _log_message method with log_flag set to False"""
+        """Tests _log_message method when log_flag is False"""
         message = "This is a test message"
         _log_message(message, log_flag=False)
         _log_message(message, log_level=logging.WARNING, log_flag=False)
@@ -213,11 +213,15 @@ class TestUtils(unittest.TestCase):
         expected_object_keys_map = {
             "mock_schema1.json": {
                 "source": "prefix1/mock_schema1.json",
-                "target": f"prefix1/original_metadata/mock_schema1.{date_stamp}.json",
+                "target": (
+                    f"prefix1/original_metadata/mock_schema1.{date_stamp}.json"
+                ),
             },
             "mock_schema2.json": {
                 "source": "prefix1/mock_schema2.json",
-                "target": f"prefix1/original_metadata/mock_schema2.{date_stamp}.json",
+                "target": (
+                    f"prefix1/original_metadata/mock_schema2.{date_stamp}.json"
+                ),
             },
         }
         result_object_keys_map = create_core_schema_object_keys_map(
@@ -676,12 +680,16 @@ class TestUtils(unittest.TestCase):
                 call(
                     s3_client=mock_s3_client,
                     bucket="aind-ephys-data-dev-u5u0i5",
-                    object_key="ecephys_642478_2023-01-17_13-56-29/processing.json",
+                    object_key=(
+                        "ecephys_642478_2023-01-17_13-56-29/processing.json"
+                    ),
                 ),
                 call(
                     s3_client=mock_s3_client,
                     bucket="aind-ephys-data-dev-u5u0i5",
-                    object_key="ecephys_642478_2023-01-17_13-56-29/subject.json",
+                    object_key=(
+                        "ecephys_642478_2023-01-17_13-56-29/subject.json"
+                    ),
                 ),
             ]
         )
@@ -899,7 +907,10 @@ class TestUtils(unittest.TestCase):
                         "Bucket": expected_bucket,
                         "Key": f"{expected_prefix}/processing.json",
                     },
-                    Key=f"{expected_prefix}/original_metadata/processing.{expected_date_stamp}.json",
+                    Key=(
+                        f"{expected_prefix}/original_metadata/"
+                        f"processing.{expected_date_stamp}.json"
+                    ),
                 ),
                 call(
                     Bucket=expected_bucket,
@@ -907,7 +918,10 @@ class TestUtils(unittest.TestCase):
                         "Bucket": expected_bucket,
                         "Key": f"{expected_prefix}/subject.json",
                     },
-                    Key=f"{expected_prefix}/original_metadata/subject.{expected_date_stamp}.json",
+                    Key=(
+                        f"{expected_prefix}/original_metadata/"
+                        f"subject.{expected_date_stamp}.json"
+                    ),
                 ),
             ]
         )
@@ -950,8 +964,8 @@ class TestUtils(unittest.TestCase):
         mock_does_s3_object_exist: MagicMock,
         mock_upload_core_record: MagicMock,
     ):
-        """Tests copy_then_overwrite_core_json_files method when an original core json
-        does not exist in generated metadata.nd.json."""
+        """Tests copy_then_overwrite_core_json_files method when an original
+        core json does not exist in generated metadata.nd.json."""
         expected_bucket = "aind-ephys-data-dev-u5u0i5"
         expected_prefix = "ecephys_642478_2023-01-17_13-56-29"
         expected_date_stamp = datetime.now().strftime("%Y%m%d")
@@ -988,7 +1002,10 @@ class TestUtils(unittest.TestCase):
                         "Bucket": expected_bucket,
                         "Key": f"{expected_prefix}/processing.json",
                     },
-                    Key=f"{expected_prefix}/original_metadata/processing.{expected_date_stamp}.json",
+                    Key=(
+                        f"{expected_prefix}/original_metadata/"
+                        f"processing.{expected_date_stamp}.json"
+                    ),
                 ),
                 call(
                     Bucket=expected_bucket,
@@ -996,7 +1013,10 @@ class TestUtils(unittest.TestCase):
                         "Bucket": expected_bucket,
                         "Key": f"{expected_prefix}/rig.json",
                     },
-                    Key=f"{expected_prefix}/original_metadata/rig.{expected_date_stamp}.json",
+                    Key=(
+                        f"{expected_prefix}/original_metadata/"
+                        f"rig.{expected_date_stamp}.json"
+                    ),
                 ),
                 call(
                     Bucket=expected_bucket,
@@ -1004,7 +1024,10 @@ class TestUtils(unittest.TestCase):
                         "Bucket": expected_bucket,
                         "Key": f"{expected_prefix}/subject.json",
                     },
-                    Key=f"{expected_prefix}/original_metadata/subject.{expected_date_stamp}.json",
+                    Key=(
+                        f"{expected_prefix}/original_metadata/"
+                        f"subject.{expected_date_stamp}.json"
+                    ),
                 ),
             ]
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,9 +90,13 @@ class TestUtils(unittest.TestCase):
             "example_list_objects_response_unexpected.json"
         )
         cls.example_list_objects_response = example_list_objects_response
-        cls.example_list_objects_response_false = example_list_objects_response_false
-        cls.example_list_objects_response_unexpected = example_list_objects_response_unexpected
-        
+        cls.example_list_objects_response_false = (
+            example_list_objects_response_false
+        )
+        cls.example_list_objects_response_unexpected = (
+            example_list_objects_response_unexpected
+        )
+
         example_get_object_response1 = load_json_file(
             "example_get_object_response1.json"
         )
@@ -215,7 +219,9 @@ class TestUtils(unittest.TestCase):
                 "target": f"prefix1/original_metadata/mock_schema2.{date_stamp}.json",
             },
         }
-        result_object_keys_map = create_core_schema_object_keys_map(prefix, target_prefix)
+        result_object_keys_map = create_core_schema_object_keys_map(
+            prefix, target_prefix
+        )
         self.assertDictEqual(expected_object_keys_map, result_object_keys_map)
 
     def test_get_s3_bucket_and_prefix(self):
@@ -397,7 +403,9 @@ class TestUtils(unittest.TestCase):
             self.example_list_objects_response
         )
         result = does_s3_prefix_exist(
-            bucket="a_bucket", prefix=provided_target_prefix, s3_client=mock_s3_client
+            bucket="a_bucket",
+            prefix=provided_target_prefix,
+            s3_client=mock_s3_client,
         )
         mock_s3_client.list_objects_v2.assert_called_once_with(
             Bucket="a_bucket", Prefix=expected_target_prefix, MaxKeys=1
@@ -413,13 +421,14 @@ class TestUtils(unittest.TestCase):
             self.example_list_objects_response_false
         )
         result = does_s3_prefix_exist(
-            bucket="a_bucket", prefix=provided_target_prefix, s3_client=mock_s3_client
+            bucket="a_bucket",
+            prefix=provided_target_prefix,
+            s3_client=mock_s3_client,
         )
         mock_s3_client.list_objects_v2.assert_called_once_with(
             Bucket="a_bucket", Prefix=expected_target_prefix, MaxKeys=1
         )
         self.assertFalse(result)
-
 
     @patch("boto3.client")
     def test_does_s3_prefix_exist_error(self, mock_s3_client: MagicMock):
@@ -429,9 +438,11 @@ class TestUtils(unittest.TestCase):
         mock_s3_client.list_objects_v2.return_value = (
             self.example_list_objects_response_unexpected
         )
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(ValueError):
             does_s3_prefix_exist(
-                bucket="a_bucket", prefix=provided_target_prefix, s3_client=mock_s3_client
+                bucket="a_bucket",
+                prefix=provided_target_prefix,
+                s3_client=mock_s3_client,
             )
         mock_s3_client.list_objects_v2.assert_called_once_with(
             Bucket="a_bucket", Prefix=expected_target_prefix, MaxKeys=1
@@ -700,6 +711,7 @@ class TestUtils(unittest.TestCase):
         # example_md_record only has processing and subject fields
         # assume /original_metadata already exists
         mock_does_s3_prefix_exist.return_value = True
+
         def mock_source_files_exist(s3_client, bucket, key):
             """Mock does_s3_object_exist function."""
             mock_exist_files = [
@@ -709,7 +721,7 @@ class TestUtils(unittest.TestCase):
             return True if key in mock_exist_files else False
 
         mock_does_s3_object_exist.side_effect = mock_source_files_exist
-        response = copy_then_overwrite_core_json_files(
+        copy_then_overwrite_core_json_files(
             metadata_json=json.dumps(self.example_metadata_nd),
             bucket=expected_bucket,
             prefix=expected_prefix,
@@ -797,6 +809,7 @@ class TestUtils(unittest.TestCase):
         # assume rig.json exists but is corrupt
         # assume /original_metadata does not exist
         mock_does_s3_prefix_exist.return_value = False
+
         def mock_source_files_exist(s3_client, bucket, key):
             """Mock does_s3_object_exist function."""
             mock_exist_files = [
@@ -807,7 +820,7 @@ class TestUtils(unittest.TestCase):
             return True if key in mock_exist_files else False
 
         mock_does_s3_object_exist.side_effect = mock_source_files_exist
-        response = copy_then_overwrite_core_json_files(
+        copy_then_overwrite_core_json_files(
             metadata_json=json.dumps(self.example_metadata_nd),
             bucket=expected_bucket,
             prefix=expected_prefix,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,7 +258,7 @@ class TestUtils(unittest.TestCase):
             "mock_schema3.json": {
                 "source": "prefix1/mock_schema3.json",
                 "target": (
-                    f"prefix1/original_metadata/mock_schema3.20240520.json"
+                    "prefix1/original_metadata/mock_schema3.20240520.json"
                 ),
             },
         }


### PR DESCRIPTION
closes #55 

**Utils:**
- `copy_then_overwrite_core_json_files`: Copies core jsons to /original_metadata, then update all top level jsons with new metadata.nd.json.
- `sync_core_json_files`: Syncs top level jsons with fields from metadata.nd.json. Use md5hash for checking updates.
- added some other helper functions

**AindPopulateMetadataJsonJob:**
- When a metadata.nd.json is created, call `copy_then_overwrite_core_json_files`

**AindIndexBucketJob:**
- `_process_docdb_record`: on docdb updates, call  `sync_core_json_files`, or `copy_then_overwrite_core_json_files` if /original_metadata doesn't already exist.
- `_process_prefix`: If adding new metadata.nd.json to docdb, call `copy_then_overwrite_core_json_files`