### PR TITLE
Feat 56 run indexer

### DIFF
--- a/src/aind_data_asset_indexer/models.py
+++ b/src/aind_data_asset_indexer/models.py
@@ -1,5 +1,6 @@
 """Module to hold job settings models"""
 
+import json
 from typing import List, Optional
 
 import boto3
@@ -56,6 +57,47 @@ class AindIndexBucketJobSettings(IndexJobSettings):
     doc_db_password: SecretStr
     doc_db_db_name: str
     doc_db_collection_name: str
+
+    @classmethod
+    def from_param_store(cls, param_store_name: str):
+        """
+        Construct class from aws param store and secrets manager
+        Parameters
+        ----------
+        param_store_name : str
+        """
+        param_store_client = boto3.client("ssm")
+        response = param_store_client.get_parameter(
+            Name=param_store_name, WithDecryption=True
+        )
+        param_store_client.close()
+        parameters = response["Parameter"]["Value"]
+        parameters_json = json.loads(parameters)
+        if "doc_db_secret_name" not in parameters:
+            raise ValueError(
+                "doc_db_secret_name not found in parameters."
+            )
+        secrets_client = boto3.client("secretsmanager")
+        docdb_secret = secrets_client.get_secret_value(
+            SecretId=parameters_json["doc_db_secret_name"]
+        )
+        secrets_client.close()
+        docdb_secret_json = json.loads(docdb_secret["SecretString"])
+        del parameters_json["doc_db_secret_name"]
+        secret_to_job_settings_map = {
+            "host": "doc_db_host",
+            "port": "doc_db_port",
+            "username": "doc_db_user_name",
+            "password": "doc_db_password",
+        }
+
+        for secret_key, job_setting in secret_to_job_settings_map.items():
+            if secret_key not in docdb_secret_json:
+                raise ValueError(
+                    f"{secret_key} not found in docdb secret."
+                )
+            parameters_json[job_setting] = docdb_secret_json[secret_key]
+        return cls.model_validate_json(json.dumps(parameters_json))
 
 
 class PopulateAindBucketsJobSettings(IndexJobSettings):

--- a/src/aind_data_asset_indexer/run.sh
+++ b/src/aind_data_asset_indexer/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python src/aind_data_asset_indexer/s3_crawler.py && python src/aind_data_asset_indexer/update_docdb.py
+python src/aind_data_asset_indexer/index_aind_buckets.py --param-store-name $PARAM_STORE_NAME

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,6 +99,85 @@ class TestAindIndexBucketJobSettings(unittest.TestCase):
             "some_docdb_collection_name", job_settings.doc_db_collection_name
         )
 
+    @patch("boto3.client")
+    def test_from_from_param_store(self, mock_boto3_client):
+        """Tests class constructor from param store."""
+        mock_boto3_client.return_value.get_parameter.return_value = {
+            "Parameter": {
+                "Name": "a_param",
+                "Type": "String",
+                "Value": (
+                    '{"doc_db_secret_name": "some_docdb_secret_name",'
+                    '"doc_db_db_name":"some_docdb_dbname",'
+                    '"doc_db_collection_name":"some_docdb_collection_name",'
+                    '"s3_bucket":"some_bucket"}'
+                ),
+                "Version": 1,
+                "LastModifiedDate": datetime(
+                    2024, 5, 4, 15, 18, 29, 8000, tzinfo=timezone.utc
+                ),
+                "ARN": "arn:aws:ssm:us-west-2:000000000000:parameter/a_param",
+                "DataType": "text",
+            },
+            "ResponseMetadata": {
+                "RequestId": "RequestId",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "server": "Server",
+                    "date": "Tue, 14 May 2024 18:14:39 GMT",
+                    "content-type": "application/x-amz-json-1.1",
+                    "content-length": "415",
+                    "connection": "keep-alive",
+                    "x-amzn-requestid": "x-amzn-requestid",
+                },
+                "RetryAttempts": 0,
+            },
+        }
+        mock_boto3_client.return_value.get_secret_value.return_value = {
+            "ARN": (
+                "arn:aws:secretsmanager:us-west-2:000000000000:secret:"
+                "some_docdb_secret_name-1a2b3c"
+            ),
+            "Name": "some_docdb_secret_name",
+            "VersionId": "VersionId",
+            "SecretString": (
+                '{"admin_secrets": "some_admin_secrets_name",'
+                '"engine": "mongo",'
+                '"host": "some_docdb_host",'
+                '"password": "some_docdb_password",'
+                '"port": 12345,'
+                '"username": "some_docdb_username"}'
+            ),
+            "VersionStages": ["AWSCURRENT", "AWSPENDING"],
+            "CreatedDate": datetime(
+                2024, 5, 20, 18, 11, 45, 174000, tzinfo=timezone.utc
+            ),
+            "ResponseMetadata": {
+                "RequestId": "RequestId",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "x-amzn-requestid": "x-amzn-requestid",
+                    "content-type": "application/x-amz-json-1.1",
+                    "content-length": "600",
+                    "date": "Tue, 28 May 2024 19:53:17 GMT",
+                },
+                "RetryAttempts": 0,
+            },
+        }
+        job_settings = AindIndexBucketJobSettings.from_param_store(
+            param_store_name="a_param"
+        )
+        expected_job_settings = AindIndexBucketJobSettings(
+            s3_bucket="some_bucket",
+            doc_db_host="some_docdb_host",
+            doc_db_port=12345,
+            doc_db_password="some_docdb_password",
+            doc_db_user_name="some_docdb_username",
+            doc_db_db_name="some_docdb_dbname",
+            doc_db_collection_name="some_docdb_collection_name",
+        )
+        self.assertEqual(expected_job_settings, job_settings)
+
 
 class TestPopulateAindBucketsJobSettings(unittest.TestCase):
     """Test PopulateAindBucketsJobSettings class"""


### PR DESCRIPTION
closes #56
- updated `run.sh`
- updated `AindIndexBucketJobSettings.from_param_store` to pull docdb job settings from aws secrets manager

At minimum, the parameter in aws parameter store should have:
```
{
  "doc_db_secret_name": "{docdb_secret_name}",
  "doc_db_db_name": "metadata_index",
  "doc_db_collection_name": "data_assets",
  "s3_buckets": [
    "{bucket1}",
    "{bucket2}",
    ...
  ]
}
```