### PR TITLE
feat: add check for _id in existing metadata.nd.json

### DIFF
--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -622,6 +622,60 @@ class TestAindIndexBucketJob(unittest.TestCase):
     @patch("aind_data_asset_indexer.aind_bucket_indexer.MongoClient")
     @patch("boto3.client")
     @patch("logging.warning")
+    def test_process_prefix_no_record_yes_file_good_file_no__id(
+        self,
+        mock_log_warn: MagicMock,
+        mock_s3_client: MagicMock,
+        mock_docdb_client: MagicMock,
+        mock_does_s3_object_exist: MagicMock,
+        mock_download_json_file_from_s3: MagicMock,
+        mock_copy_then_overwrite_core_json_files: MagicMock,
+        mock_upload_metadata_json_str_to_s3: MagicMock,
+    ):
+        """Tests _process_prefix method when there is no record in DocDb,
+        there is and there is metadata.nd.json file in S3, and the file can
+        be serialized to json, but there is no _id in the file."""
+        mock_db = MagicMock()
+        mock_docdb_client.__getitem__.return_value = mock_db
+        mock_collection = MagicMock()
+        mock_db.__getitem__.return_value = mock_collection
+
+        mock_does_s3_object_exist.return_value = True
+        mocked_downloaded_record = deepcopy(self.example_md_record)
+        del mocked_downloaded_record["_id"]
+        mock_download_json_file_from_s3.return_value = mocked_downloaded_record
+
+        location_to_id_map = dict()
+        self.basic_job._process_prefix(
+            s3_prefix="ecephys_642478_2023-01-17_13-56-29",
+            docdb_client=mock_docdb_client,
+            s3_client=mock_s3_client,
+            location_to_id_map=location_to_id_map,
+        )
+        mock_collection.assert_not_called()
+        mock_copy_then_overwrite_core_json_files.assert_not_called()
+        mock_upload_metadata_json_str_to_s3.assert_not_called()
+        mock_log_warn.assert_called_once_with(
+            "Metadata record for s3://aind-ephys-data-dev-u5u0i5/"
+            "ecephys_642478_2023-01-17_13-56-29 does not have an _id field!"
+        )
+
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "upload_metadata_json_str_to_s3"
+    )
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "copy_then_overwrite_core_json_files"
+    )
+    @patch(
+        "aind_data_asset_indexer.aind_bucket_indexer."
+        "download_json_file_from_s3"
+    )
+    @patch("aind_data_asset_indexer.aind_bucket_indexer.does_s3_object_exist")
+    @patch("aind_data_asset_indexer.aind_bucket_indexer.MongoClient")
+    @patch("boto3.client")
+    @patch("logging.warning")
     def test_process_prefix_no_record_yes_file_good_file_bad_location(
         self,
         mock_log_warn: MagicMock,


### PR DESCRIPTION
closes #64 
- add check for `_id` in existing metadata.nd.json to mitigate unhandled key errors