### PR TITLE
hot-fix: original metadata checks

### DIFF
--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -262,6 +262,17 @@ class AindIndexBucketJob:
                     docdb_record_contents=docdb_record.get(field_name),
                     **common_kwargs,
                 )
+                # Get file info for new file in root folder
+                object_key = create_object_key(
+                    prefix=prefix, filename=core_schema_file_name
+                )
+                common_kwargs["core_schema_info_in_root"] = (
+                    get_dict_of_file_info(
+                        s3_client=s3_client,
+                        bucket=self.job_settings.s3_bucket,
+                        keys=[object_key],
+                    ).get(object_key)
+                )
                 self._copy_file_from_root_to_subdir(**common_kwargs)
             # If field is null, a file exists in the root folder, and
             # a file exists in copy_subdir, then delete file from root folder

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -313,6 +313,11 @@ class AindIndexBucketJob:
                         f"Something went wrong downloading or parsing "
                         f"s3://{self.job_settings.s3_bucket}/{object_key}"
                     )
+                    # Can delete corrupt root file since a copy was already made
+                    response = s3_client.delete_object(
+                        Bucket=self.job_settings.s3_bucket, Key=object_key
+                    )
+                    logging.debug(f"{response}")
 
             # If field is null, no file exists in the root folder, and
             # a file exists in copy_subdir, then do nothing

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -313,7 +313,7 @@ class AindIndexBucketJob:
                         f"Something went wrong downloading or parsing "
                         f"s3://{self.job_settings.s3_bucket}/{object_key}"
                     )
-                    # Can delete corrupt root file since a copy was already made
+                    # Can delete corrupt root file since a copy has been made
                     response = s3_client.delete_object(
                         Bucket=self.job_settings.s3_bucket, Key=object_key
                     )

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -233,7 +233,8 @@ class AindIndexBucketJob:
             # with record info if they are different
             if is_in_record and is_in_root and is_in_copy_subdir:
                 self._write_root_file_with_record_info(
-                    docdb_record=docdb_record.get(field_name), **common_kwargs
+                    docdb_record_contents=docdb_record.get(field_name),
+                    **common_kwargs,
                 )
             # If field is not null, a file exists in the root folder, and
             # no file exists in copy_subdir, then copy root folder file to
@@ -242,21 +243,24 @@ class AindIndexBucketJob:
             elif is_in_record and is_in_root and not is_in_copy_subdir:
                 self._copy_file_from_root_to_subdir(**common_kwargs)
                 self._write_root_file_with_record_info(
-                    docdb_record=docdb_record.get(field_name), **common_kwargs
+                    docdb_record_contents=docdb_record.get(field_name),
+                    **common_kwargs,
                 )
             # If field is not null, no file exists in the root folder, and
             # a file exists in copy_subdir, then create a file in the root
             # folder with the record info
             elif is_in_record and not is_in_root and is_in_copy_subdir:
                 self._write_root_file_with_record_info(
-                    docdb_record=docdb_record.get(field_name), **common_kwargs
+                    docdb_record_contents=docdb_record.get(field_name),
+                    **common_kwargs,
                 )
             # If field is not null, no file exists in the root folder, and
             # no file exists in copy_subdir, then create a file in the root
             # folder with the record info and then copy it to the copy subdir
             elif is_in_record and not is_in_root and not is_in_copy_subdir:
                 self._write_root_file_with_record_info(
-                    docdb_record=docdb_record.get(field_name), **common_kwargs
+                    docdb_record_contents=docdb_record.get(field_name),
+                    **common_kwargs,
                 )
                 self._copy_file_from_root_to_subdir(**common_kwargs)
             # If field is null, a file exists in the root folder, and

--- a/src/aind_data_asset_indexer/utils.py
+++ b/src/aind_data_asset_indexer/utils.py
@@ -351,11 +351,10 @@ def does_s3_metadata_copy_exist(
         Bucket=bucket, Prefix=copy_prefix, Delimiter="/"
     )
     if "Contents" in response:
-        core_schemas = [s.rstrip(".json") for s in core_schema_file_names]
-        pattern = r"([a-zA-Z0-9_]+)\.\d{8}\.json$"
+        core_schemas = [s.replace(".json", "") for s in core_schema_file_names]
+        pattern = re.escape(copy_prefix) + r"([a-zA-Z0-9_]+)\.\d{8}\.json$"
         for obj in response["Contents"]:
-            file_name = obj["Key"].lstrip(copy_prefix)
-            m = re.match(pattern, file_name)
+            m = re.match(pattern, obj["Key"])
             if m is not None and m.group(1) in core_schemas:
                 return True
     return False
@@ -393,11 +392,10 @@ def list_metadata_copies(
     )
     files = []
     if "Contents" in response:
-        core_schemas = [s.rstrip(".json") for s in core_schema_file_names]
-        pattern = r"([a-zA-Z0-9_]+)\.\d{8}\.json$"
+        core_schemas = [s.replace(".json", "") for s in core_schema_file_names]
+        pattern = re.escape(copy_prefix) + r"([a-zA-Z0-9_]+)\.\d{8}\.json$"
         for obj in response["Contents"]:
-            file_name = obj["Key"].lstrip(copy_prefix)
-            m = re.match(pattern, file_name)
+            m = re.match(pattern, obj["Key"])
             if m is not None and m.group(1) in core_schemas:
                 files.append(f"{m.group(1)}.json")
     return files

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -243,7 +243,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
         )
         self.assertEqual(dict(), docdb_fields_to_update)
         mock_write_file_with_record_info.assert_called_once_with(
-            docdb_record=self.example_md_record.get("subject"),
+            docdb_record_contents=self.example_md_record.get("subject"),
             s3_client=mock_s3_client,
             prefix="ecephys_642478_2023-01-17_13-56-29",
             core_schema_file_name="subject.json",
@@ -316,7 +316,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             ),
         )
         mock_write_file_with_record_info.assert_called_once_with(
-            docdb_record=self.example_md_record.get("subject"),
+            docdb_record_contents=self.example_md_record.get("subject"),
             s3_client=mock_s3_client,
             prefix="ecephys_642478_2023-01-17_13-56-29",
             core_schema_file_name="subject.json",
@@ -373,7 +373,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
         self.assertEqual(dict(), docdb_fields_to_update)
         mock_copy_file_to_subdir.assert_not_called()
         mock_write_file_with_record_info.assert_called_once_with(
-            docdb_record=self.example_md_record.get("subject"),
+            docdb_record_contents=self.example_md_record.get("subject"),
             s3_client=mock_s3_client,
             prefix="ecephys_642478_2023-01-17_13-56-29",
             core_schema_file_name="subject.json",
@@ -429,7 +429,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
         )
         self.assertEqual(dict(), docdb_fields_to_update)
         mock_write_file_with_record_info.assert_called_once_with(
-            docdb_record=self.example_md_record.get("subject"),
+            docdb_record_contents=self.example_md_record.get("subject"),
             s3_client=mock_s3_client,
             prefix="ecephys_642478_2023-01-17_13-56-29",
             core_schema_file_name="subject.json",

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -662,13 +662,17 @@ class TestAindIndexBucketJob(unittest.TestCase):
                 "subject.json"
             ),
         )
-        mock_log_debug.assert_not_called()
         mock_log_info.assert_not_called()
         mock_log_warn.assert_called_once_with(
             "Something went wrong downloading or parsing "
             "s3://aind-ephys-data-dev-u5u0i5/"
             "ecephys_642478_2023-01-17_13-56-29/subject.json"
         )
+        mock_s3_client.delete_object.assert_called_once_with(
+            Bucket="aind-ephys-data-dev-u5u0i5",
+            Key="ecephys_642478_2023-01-17_13-56-29/subject.json",
+        )
+        mock_log_debug.assert_called_once()
 
     @patch("boto3.client")
     @patch("logging.debug")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -521,7 +521,7 @@ class TestUtils(unittest.TestCase):
             copy_subdir="original_metadata",
             s3_client=mock_s3_client,
         )
-        self.assertEqual(["subject.json"], contents)
+        self.assertEqual(["data_description.json", "subject.json"], contents)
 
     @patch("boto3.client")
     def test_does_s3_metadata_copy_exist_none(self, mock_s3_client: MagicMock):


### PR DESCRIPTION
related to #79

This PR fixes a few small issues related to `_resolve_schema_information()`:
- When `is_in_record=True`, `is_in_root=False`, and `is_in_copy_subdir-False`: get file info of new root file for the copy operation
- When `is_in_record=False`, `is_in_root=True`, and `is_in_copy_subdir-True` and root file is corrupt: delete root file after copy is made
- `strip` does not work for substring matching. Updated regex pattern instead
- fixes a typo with one of the param names