### PR TITLE
feat: adds method to attach links to external data assets

### DIFF
--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -266,12 +266,14 @@ class AindIndexBucketJob:
                 object_key = create_object_key(
                     prefix=prefix, filename=core_schema_file_name
                 )
-                common_kwargs["core_schema_info_in_root"] = (
-                    get_dict_of_file_info(
-                        s3_client=s3_client,
-                        bucket=self.job_settings.s3_bucket,
-                        keys=[object_key],
-                    ).get(object_key)
+                common_kwargs[
+                    "core_schema_info_in_root"
+                ] = get_dict_of_file_info(
+                    s3_client=s3_client,
+                    bucket=self.job_settings.s3_bucket,
+                    keys=[object_key],
+                ).get(
+                    object_key
                 )
                 self._copy_file_from_root_to_subdir(**common_kwargs)
             # If field is null, a file exists in the root folder, and

--- a/src/aind_data_asset_indexer/models.py
+++ b/src/aind_data_asset_indexer/models.py
@@ -122,6 +122,12 @@ class CodeOceanIndexBucketJobSettings(IndexJobSettings):
     doc_db_collection_name: str
     codeocean_domain: str
     codeocean_token: SecretStr
+    temp_codeocean_endpoint: str = Field(
+        description=(
+            "Temp proxy to access code ocean information from their analytics "
+            "databases."
+        )
+    )
 
     @classmethod
     def from_param_store(cls, param_store_name: str):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -236,6 +236,7 @@ class TestCodeOceanIndexBucketJobSettings(unittest.TestCase):
             doc_db_collection_name="some_docdb_collection_name",
             codeocean_domain="some_co_domain",
             codeocean_token="some_co_token",
+            temp_codeocean_endpoint="http://some_url:8080/created_after/0",
         )
         self.assertEqual("some_bucket", job_settings.s3_bucket)
         self.assertEqual(20, job_settings.n_partitions)
@@ -255,6 +256,10 @@ class TestCodeOceanIndexBucketJobSettings(unittest.TestCase):
         self.assertEqual(
             "some_co_token", job_settings.codeocean_token.get_secret_value()
         )
+        self.assertEqual(
+            "http://some_url:8080/created_after/0",
+            job_settings.temp_codeocean_endpoint,
+        )
 
     @patch("boto3.client")
     def test_from_from_param_store(self, mock_boto3_client):
@@ -268,6 +273,8 @@ class TestCodeOceanIndexBucketJobSettings(unittest.TestCase):
                     '"codeocean_secret_name": "some_codeocean_secret_name",'
                     '"doc_db_db_name":"some_docdb_dbname",'
                     '"doc_db_collection_name":"some_docdb_collection_name",'
+                    '"temp_codeocean_endpoint":'
+                    '"http://some_url:8080/created_after/0",'
                     '"s3_bucket":"some_bucket"}'
                 ),
                 "Version": 1,
@@ -363,6 +370,7 @@ class TestCodeOceanIndexBucketJobSettings(unittest.TestCase):
             doc_db_collection_name="some_docdb_collection_name",
             codeocean_domain="some_co_domain",
             codeocean_token="some_co_token",
+            temp_codeocean_endpoint="http://some_url:8080/created_after/0",
         )
         self.assertEqual(expected_job_settings, job_settings)
 


### PR DESCRIPTION
Closes #77

- Assumes temp proxy is running. May need to update this once code ocean fixes bug with their search all function
- Adds step in CodeOceanBucketIndexer to also loop through and update external links to data assets. Assumes Code Ocean is only platform.