### PR TITLE
feat: enable special chars in fieldnames

### DIFF
--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Optional
 
 import boto3
 import dask.bag as dask_bag
-from aind_data_schema.base import is_dict_corrupt
 from mypy_boto3_s3 import S3Client
 from mypy_boto3_s3.type_defs import CopySourceTypeDef
 from pymongo import MongoClient
@@ -308,11 +307,7 @@ class AindIndexBucketJob:
                     bucket=self.job_settings.s3_bucket,
                     object_key=object_key,
                 )
-                if file_contents is None:
-                    is_file_corrupt = True
-                else:
-                    is_file_corrupt = is_dict_corrupt(file_contents)
-                if not is_file_corrupt:
+                if file_contents is not None:
                     docdb_record_fields_to_update[field_name] = file_contents
                 else:
                     logging.warning(
@@ -578,9 +573,7 @@ class AindIndexBucketJob:
                         collection = db[
                             self.job_settings.doc_db_collection_name
                         ]
-                        if "_id" in json_contents and not is_dict_corrupt(
-                            json_contents
-                        ):
+                        if "_id" in json_contents:
                             logging.info(
                                 f"Adding record to docdb for: {location}"
                             )
@@ -600,10 +593,6 @@ class AindIndexBucketJob:
                                 copy_original_md_subdir=(
                                     self.job_settings.copy_original_md_subdir
                                 ),
-                            )
-                        elif "_id" in json_contents:
-                            logging.warning(
-                                f"Metadata record for {location} is corrupt!"
                             )
                         else:
                             logging.warning(

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -577,12 +577,8 @@ class AindIndexBucketJob:
                             logging.info(
                                 f"Adding record to docdb for: {location}"
                             )
-                            response = collection.update_one(
-                                {"_id": json_contents["_id"]},
-                                {"$set": json_contents},
-                                upsert=True,
-                            )
-                            logging.debug(response.raw_result)
+                            response = collection.insert_one(json_contents)
+                            logging.debug(response.inserted_id)
                             cond_copy_then_sync_core_json_files(
                                 metadata_json=json.dumps(
                                     json_contents, default=str

--- a/src/aind_data_asset_indexer/codeocean_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/codeocean_bucket_indexer.py
@@ -296,12 +296,8 @@ class CodeOceanIndexBucketJob:
             collection = db[self.job_settings.doc_db_collection_name]
             # noinspection PyTypeChecker
             json_contents = json.loads(new_metadata_contents)
-            x = collection.update_one(
-                {"_id": json_contents["_id"]},
-                {"$set": json_contents},
-                upsert=True,
-            )
-            logging.debug(x.raw_result)
+            x = collection.insert_one(json_contents)
+            logging.debug(x.inserted_id)
         else:
             logging.warning(
                 f"Unable to build metadata record for: {location}!"

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 from bson.timestamp import Timestamp
-from pymongo.results import DeleteResult, UpdateResult
+from pymongo.results import DeleteResult, InsertOneResult
 
 from aind_data_asset_indexer.aind_bucket_indexer import AindIndexBucketJob
 from aind_data_asset_indexer.models import AindIndexBucketJobSettings
@@ -1270,15 +1270,8 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_docdb_client.__getitem__.return_value = mock_db
         mock_collection = MagicMock()
         mock_db.__getitem__.return_value = mock_collection
-        mock_collection.update_one.return_value = UpdateResult(
-            raw_result={
-                "n": 1,
-                "nModified": 0,
-                "upserted": "488bbe42-832b-4c37-8572-25eb87cc50e2",
-                "ok": 1.0,
-                "operationTime": Timestamp(1715819252, 1),
-                "updatedExisting": False,
-            },
+        mock_collection.insert_one.return_value = InsertOneResult(
+            inserted_id="488bbe42-832b-4c37-8572-25eb87cc50e2",
             acknowledged=True,
         )
 
@@ -1297,13 +1290,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             "INFO:root:Adding record to docdb for: "
             "s3://aind-ephys-data-dev-u5u0i5/"
             "ecephys_642478_2023-01-17_13-56-29",
-            "DEBUG:root:"
-            "{'n': 1, "
-            "'nModified': 0, "
-            "'upserted': '488bbe42-832b-4c37-8572-25eb87cc50e2', "
-            "'ok': 1.0, "
-            "'operationTime': Timestamp(1715819252, 1), "
-            "'updatedExisting': False}",
+            "DEBUG:root:488bbe42-832b-4c37-8572-25eb87cc50e2",
         ]
         self.assertEqual(expected_log_messages, captured.output)
         mock_cond_copy_then_sync_core_json_files.assert_called_once_with(

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -1323,62 +1323,6 @@ class TestAindIndexBucketJob(unittest.TestCase):
         "aind_data_asset_indexer.aind_bucket_indexer."
         "cond_copy_then_sync_core_json_files"
     )
-    @patch("aind_data_asset_indexer.aind_bucket_indexer.is_dict_corrupt")
-    @patch(
-        "aind_data_asset_indexer.aind_bucket_indexer."
-        "download_json_file_from_s3"
-    )
-    @patch("aind_data_asset_indexer.aind_bucket_indexer.does_s3_object_exist")
-    @patch("aind_data_asset_indexer.aind_bucket_indexer.MongoClient")
-    @patch("boto3.client")
-    def test_process_prefix_no_record_yes_file_corrupt_file(
-        self,
-        mock_s3_client: MagicMock,
-        mock_docdb_client: MagicMock,
-        mock_does_s3_object_exist: MagicMock,
-        mock_download_json_file_from_s3: MagicMock,
-        mock_is_dict_corrupt: MagicMock,
-        mock_cond_copy_then_sync_core_json_files: MagicMock,
-        mock_upload_metadata_json_str_to_s3: MagicMock,
-    ):
-        """Tests _process_prefix method when there is no record in DocDb,
-        there is and there is metadata.nd.json file in S3, and the file can
-        be serialized to json, but its contents are corrupt."""
-        mock_db = MagicMock()
-        mock_docdb_client.__getitem__.return_value = mock_db
-        mock_collection = MagicMock()
-        mock_db.__getitem__.return_value = mock_collection
-
-        mock_does_s3_object_exist.return_value = True
-        mocked_downloaded_record = deepcopy(self.example_md_record)
-        mock_download_json_file_from_s3.return_value = mocked_downloaded_record
-        mock_is_dict_corrupt.return_value = True
-
-        location_to_id_map = dict()
-        with self.assertLogs(level="DEBUG") as captured:
-            self.basic_job._process_prefix(
-                s3_prefix="ecephys_642478_2023-01-17_13-56-29",
-                docdb_client=mock_docdb_client,
-                s3_client=mock_s3_client,
-                location_to_id_map=location_to_id_map,
-            )
-        expected_log_messages = [
-            "WARNING:root:Metadata record for s3://aind-ephys-data-dev-u5u0i5/"
-            "ecephys_642478_2023-01-17_13-56-29 is corrupt!"
-        ]
-        self.assertEqual(expected_log_messages, captured.output)
-        mock_collection.assert_not_called()
-        mock_cond_copy_then_sync_core_json_files.assert_not_called()
-        mock_upload_metadata_json_str_to_s3.assert_not_called()
-
-    @patch(
-        "aind_data_asset_indexer.aind_bucket_indexer."
-        "upload_metadata_json_str_to_s3"
-    )
-    @patch(
-        "aind_data_asset_indexer.aind_bucket_indexer."
-        "cond_copy_then_sync_core_json_files"
-    )
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer."
         "download_json_file_from_s3"


### PR DESCRIPTION
closes #120

This PR includes changes to enable "$" or "." characters in fieldnames:
- Removes `is_dict_corrupt` check when writing to documentDB.
- Refactors to use `insert_one` when writing new records

Please note: I will be refactoring the indexer to write to DocDB using a lambda function instead of the direct connection. The lambda function will also need new insert apis.