### PR TITLE
fix: do not update unchanged external_links

### DIFF
--- a/src/aind_data_asset_indexer/utils.py
+++ b/src/aind_data_asset_indexer/utils.py
@@ -811,10 +811,6 @@ def get_all_processed_codeocean_asset_records(
 
     """
 
-    # We need to break up the search query until Code Ocean fixes a bug in
-    # their search API. This may still break if the number of records in an
-    # individual response exceeds 10,000
-
     all_responses = dict()
 
     for tag in {DataLevel.DERIVED.value, "processed"}:

--- a/tests/test_codeocean_bucket_indexer.py
+++ b/tests/test_codeocean_bucket_indexer.py
@@ -266,6 +266,11 @@ class TestCodeOceanIndexBucketJob(unittest.TestCase):
                     "location": "s3://bucket2/prefix3",
                     "external_links": [{"Code Ocean": "xyz-789"}],
                 },
+                {
+                    "_id": "0003",
+                    "location": "s3://bucket2/prefix4",
+                    "external_links": [],
+                },
             ]
         ]
 


### PR DESCRIPTION
This PR should fix #94.

The bug is caused by empty co links being repeatedly updated in docdb (and thus also s3 since last_modified field changes too). The fix is to check for non-empty list instead of None.