### PR TITLE
feat: lookback_days and perf improvements

### DIFF
--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -46,7 +46,10 @@ runs the `AindIndexBucketJob` for a list of buckets.
 
 The workflow is generally as follows:
 
-1. Paginate DocDB to get all records for a particular bucket.
+1. Paginate DocDB to get records for a particular bucket.
+
+   -  Typically we filter for records that have been updated in the last
+      14 days.
 2. For each DocDB record, process by syncing any changes in DocDB to S3.
 
    -  If the record does not have a valid location, log a warning.

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -689,7 +689,7 @@ class AindIndexBucketJob:
         # create clients here since dask doesn't serialize them
         s3_client = boto3.client("s3")
         with self._create_docdb_client() as doc_db_client:
-            # For the given prefix list, download all the records from docdb
+            # For the given prefix list, get record ids from docdb
             # with those locations.
             location_to_id_map = build_docdb_location_to_id_map(
                 bucket=self.job_settings.s3_bucket,

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -461,8 +461,8 @@ class AindIndexBucketJob:
     ) -> None:
         """
         The task to perform within a partition. If n_partitions is set to 20
-        and the outer record list had length 1000, then this should process
-        50 records.
+        and the outer record list had length 500, then this should process
+        25 records.
 
         Parameters
         ----------
@@ -491,7 +491,7 @@ class AindIndexBucketJob:
 
     def _process_records(self, records: List[dict]):
         """
-        For a list of records (up to a 1000 in the list), divvy up the list
+        For a list of records (up to 500 in the list), divvy up the list
         across n_partitions. Process the set of records in each partition.
 
         Parameters
@@ -720,7 +720,8 @@ class AindIndexBucketJob:
                 },
             )
             for page in docdb_pages:
-                self._process_records(records=page)
+                if len(page) > 0:
+                    self._process_records(records=page)
         logging.info("Finished scanning through DocDb.")
         logging.info("Starting to scan through S3.")
         iterator_s3_client = boto3.client("s3")
@@ -728,9 +729,8 @@ class AindIndexBucketJob:
             s3_client=iterator_s3_client, bucket=self.job_settings.s3_bucket
         )
         for prefix_list in prefix_iterator:
-            self._process_prefixes(
-                prefixes=prefix_list,
-            )
+            if len(prefix_list) > 0:
+                self._process_prefixes(prefixes=prefix_list)
         iterator_s3_client.close()
         logging.info("Finished scanning through S3.")
 

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -443,7 +443,13 @@ class AindIndexBucketJob:
                         }
                     )
                     logging.debug(response.json())
-                docdb_record.update(fields_to_update)
+                    # Pull record from docdb to get new last_modified as well
+                    docdb_response = docdb_client.retrieve_docdb_records(
+                        filter_query={"_id": docdb_record["_id"]},
+                        paginate=False,
+                    )
+                    docdb_record = docdb_response[0]
+                # Sync docdb record to metadata.nd.json in root folder
                 metadata_nd_json_info = get_dict_of_file_info(
                     s3_client=s3_client,
                     bucket=s3_bucket,

--- a/src/aind_data_asset_indexer/codeocean_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/codeocean_bucket_indexer.py
@@ -311,7 +311,7 @@ class CodeOceanIndexBucketJob:
     def _dask_task_to_process_record_list(self, record_list: List[dict]):
         """
         The task to perform within a partition. If n_partitions is set to 20
-        and the outer prefix list had length 1000, then this should process
+        and the outer record list had length 1000, then this should process
         50 code ocean records.
 
         Parameters
@@ -356,7 +356,7 @@ class CodeOceanIndexBucketJob:
     def _dask_task_to_delete_record_list(self, record_list: List[str]):
         """
         The task to perform within a partition. If n_partitions is set to 20
-        and the outer prefix list had length 1000, then this should process
+        and the outer record list had length 1000, then this should process
         50 ids.
 
         Parameters
@@ -444,13 +444,17 @@ class CodeOceanIndexBucketJob:
             records_to_add.append(code_ocean_records[location])
         for location in docdb_locations - codeocean_locations:
             records_to_delete.append(all_docdb_records[location])
+        logging.info(f"{len(records_to_add)} records to add to DocDB.")
+        logging.info(f"{len(records_to_delete)} records to delete from DocDB.")
 
-        logging.info("Starting to add records to DocDB.")
-        self._process_codeocean_records(records=records_to_add)
-        logging.info("Finished adding records to DocDB.")
-        logging.info("Starting to delete records from DocDB.")
-        self._delete_records_from_docdb(record_list=records_to_delete)
-        logging.info("Finished deleting records from DocDB.")
+        if len(records_to_add) > 0:
+            logging.info("Starting to add records to DocDB.")
+            self._process_codeocean_records(records=records_to_add)
+            logging.info("Finished adding records to DocDB.")
+        if len(records_to_delete) > 0:
+            logging.info("Starting to delete records from DocDB.")
+            self._delete_records_from_docdb(record_list=records_to_delete)
+            logging.info("Finished deleting records from DocDB.")
 
 
 if __name__ == "__main__":

--- a/src/aind_data_asset_indexer/models.py
+++ b/src/aind_data_asset_indexer/models.py
@@ -18,7 +18,7 @@ class IndexJobSettings(BaseSettings):
     lookback_days: Optional[int] = Field(
         default=None,
         description=(
-            "Records from S3 and DocDB will be filtered by this date time. If "
+            "Records from DocDB will be filtered by this date time. If "
             "set to None, then all records will be processed."
         ),
     )

--- a/tests/test_aind_bucket_indexer.py
+++ b/tests/test_aind_bucket_indexer.py
@@ -936,7 +936,9 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_s3_client = MagicMock()
         mock_boto3_client.return_value = mock_s3_client
         mock_docdb_api_client = MagicMock()
-        mock_docdb_client.return_value = mock_docdb_api_client
+        mock_docdb_client.return_value.__enter__.return_value = (
+            mock_docdb_api_client
+        )
         records = [
             self.example_md_record,
             self.example_md_record1,
@@ -963,7 +965,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             ]
         )
         mock_s3_client.close.assert_called_once_with()
-        mock_docdb_api_client.close.assert_called_once_with()
+        mock_docdb_client.return_value.__exit__.assert_called_once()
 
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer.AindIndexBucketJob."
@@ -982,7 +984,9 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_s3_client = MagicMock()
         mock_boto3_client.return_value = mock_s3_client
         mock_docdb_api_client = MagicMock()
-        mock_docdb_client.return_value = mock_docdb_api_client
+        mock_docdb_client.return_value.__enter__.return_value = (
+            mock_docdb_api_client
+        )
         records = [
             self.example_md_record,
             self.example_md_record1,
@@ -1025,7 +1029,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             ]
         )
         mock_s3_client.close.assert_called_once_with()
-        mock_docdb_api_client.close.assert_called_once_with()
+        mock_docdb_client.return_value.__exit__.assert_called_once()
 
     @patch("dask.bag.map_partitions")
     def test_process_records(self, mock_dask_bag_map_parts: MagicMock):
@@ -1450,7 +1454,9 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_s3_client = MagicMock()
         mock_boto3_client.return_value = mock_s3_client
         mock_docdb_api_client = MagicMock()
-        mock_docdb_client.return_value = mock_docdb_api_client
+        mock_docdb_client.return_value.__enter__.return_value = (
+            mock_docdb_api_client
+        )
         prefixes = [
             "ecephys_642478_2023-01-17_13-56-29",
             "ecephys_567890_2000-01-01_04-00-00",
@@ -1489,7 +1495,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             ]
         )
         mock_s3_client.close.assert_called_once_with()
-        mock_docdb_api_client.close.assert_called_once_with()
+        mock_docdb_client.return_value.__exit__.assert_called_once()
 
     @patch(
         "aind_data_asset_indexer.aind_bucket_indexer."
@@ -1513,7 +1519,9 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_s3_client = MagicMock()
         mock_boto3_client.return_value = mock_s3_client
         mock_docdb_api_client = MagicMock()
-        mock_docdb_client.return_value = mock_docdb_api_client
+        mock_docdb_client.return_value.__enter__.return_value = (
+            mock_docdb_api_client
+        )
         prefixes = [
             "ecephys_642478_2023-01-17_13-56-29",
             "ecephys_567890_2000-01-01_04-00-00",
@@ -1566,7 +1574,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
             ]
         )
         mock_s3_client.close.assert_called_once_with()
-        mock_docdb_api_client.close.assert_called_once_with()
+        mock_docdb_client.return_value.__exit__.assert_called_once()
 
     @patch("dask.bag.map_partitions")
     def test_process_prefixes(self, mock_dask_bag_map_parts: MagicMock):
@@ -1608,7 +1616,9 @@ class TestAindIndexBucketJob(unittest.TestCase):
         mock_s3_client = MagicMock()
         mock_boto3_client.return_value = mock_s3_client
         mock_docdb_api_client = MagicMock()
-        mock_docdb_client.return_value = mock_docdb_api_client
+        mock_docdb_client.return_value.__enter__.return_value = (
+            mock_docdb_api_client
+        )
         mock_paginate.return_value = iter(
             [
                 [
@@ -1637,7 +1647,7 @@ class TestAindIndexBucketJob(unittest.TestCase):
         ]
         self.assertEqual(expected_log_messages, captured.output)
 
-        mock_docdb_api_client.close.assert_called_once()
+        mock_docdb_client.return_value.__exit__.assert_called_once()
         mock_s3_client.close.assert_called_once()
         mock_process_records.assert_called_once_with(
             records=[

--- a/tests/test_codeocean_bucket_indexer.py
+++ b/tests/test_codeocean_bucket_indexer.py
@@ -630,6 +630,8 @@ class TestCodeOceanIndexBucketJob(unittest.TestCase):
             "INFO:root:Adding links to records.",
             "INFO:root:Finished adding links to records",
             "INFO:root:Finished scanning through DocDB.",
+            "INFO:root:1 records to add to DocDB.",
+            "INFO:root:1 records to delete from DocDB.",
             "INFO:root:Starting to add records to DocDB.",
             "INFO:root:Finished adding records to DocDB.",
             "INFO:root:Starting to delete records from DocDB.",


### PR DESCRIPTION
closes #98

The index jobs have been updated to use:
- `lookback_days` to only sync recently modified docdb records to s3
- custom sessions to enable docdb api retries
- batch updates to docdb wherever possible

Additionally,
- fixes issue with empty batches creating unused connections
- fixes issue where record is not re-fetched from docdb after `fields_to_update` is written

I've updated param store with `lookback_days`=14