### PR TITLE
hotfix: catch bucket job errors and increase backoff_factor for docdb

### DIFF
--- a/src/aind_data_asset_indexer/__init__.py
+++ b/src/aind_data_asset_indexer/__init__.py
@@ -1,3 +1,3 @@
 """Package"""
 
-__version__ = "0.15.0"
+__version__ = "0.16.1"

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -761,7 +761,7 @@ class AindIndexBucketJob:
             logging.info(f"Starting to scan through DocDb: {filter}")
             docdb_pages = paginate_docdb(
                 docdb_api_client=iterator_docdb_client,
-                page_size=500,
+                page_size=200,
                 filter_query=filter,
             )
             for page in docdb_pages:

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -81,7 +81,7 @@ class AindIndexBucketJob:
         """Create a MetadataDbClient with custom retries."""
         retry = Retry(
             total=3,
-            backoff_factor=1,
+            backoff_factor=10,
             status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=["GET", "POST", "DELETE"],
         )

--- a/src/aind_data_asset_indexer/codeocean_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/codeocean_bucket_indexer.py
@@ -55,7 +55,7 @@ class CodeOceanIndexBucketJob:
         """Create a MetadataDbClient with custom retries."""
         retry = Retry(
             total=3,
-            backoff_factor=1,
+            backoff_factor=10,
             status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=["GET", "POST", "DELETE"],
         )

--- a/src/aind_data_asset_indexer/index_aind_buckets.py
+++ b/src/aind_data_asset_indexer/index_aind_buckets.py
@@ -32,7 +32,10 @@ class IndexAindBucketsJob:
                 s3_bucket=bucket, **base_job_configs
             )
             bucket_job = AindIndexBucketJob(job_settings=bucket_job_settings)
-            bucket_job.run_job()
+            try:
+                bucket_job.run_job()
+            except Exception as e:
+                logging.error(f"Error processing {bucket}. Error: {e}")
             logging.info(f"Finished processing {bucket}")
 
 


### PR DESCRIPTION
- Logs bucket job errors and continues other jobs.
- Increase backoff_factor for docdb retries
- Adjust docdb page size to 200