### PR TITLE
fix: do not create .nd.json for non-derived assets

### DIFF
--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -62,8 +62,10 @@ The workflow is generally as follows:
    
    -  If the metadata record exists in S3 but not in DocDB, copy it
       to DocDB.
-   -  If the metadata record does not exist in S3, create it and save
-      it to S3. Assume a Lambda function will move it over to DocDB.
+   -  If the metadata record for a derived asset does not exist in S3,
+      create it and save it to S3. Assume a Lambda function will move it
+      over to DocDB. Metadata records for raw assets are created during
+      the upload process, **not** by this job.
    -  In both cases above, ensure the original metadata folder and core
       files are in sync with the metadata.nd.json file.
 


### PR DESCRIPTION
fixes #156 

Fixes bug where long-running uploads were indexed into DocDB before they were ready.

This PR updates the AIND bucket index job to only create missing .nd.json files in S3 if the asset is a derived asset. The data_description file in S3 is used to determine if an asset is raw or derived.

Users must make sure they are adding the data_description.json files when creating derived assets if they want to continue using the auto-indexing feature.