### PR TITLE
feat: update AindIndexBucketJob to use asset registration api

### DIFF
--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -16,17 +16,17 @@ kept in sync:
 
    -  ``{core_schema}.json``: core schema files, e.g.,
       ``acquisition.json``, ``subject.json``.
-   -  ``metadata.nd.json``: top-level metadata file, containing
-      all core schema fields.
+   -  ``metadata.nd.json``: top-level metadata file, containing all core schema
+      schema fields. This file is for reference only and may be removed soon.
    -  ``original_metadata/{core_schema}.json``: a copy of each
       core schema file as it was originally uploaded to S3.
 2. A **document database (DocDB)** contains unstructured JSON
-   documents describing the ``metadata.nd.json`` for a data asset.
+   documents describing the top-level metadata (containing all core schema fields) for a data asset.
 3. **Code Ocean**: data assets are mounted as Code Ocean data assets.
    Processed results are also stored in an internal Code Ocean bucket.
 
-Once the data is initially uploaded, the DocDB is assumed to be the
-source of truth for metadata. All updates to existing metadata should
+Once the data is initially uploaded and "registered" (added to DocDB and Code Ocean), 
+the DocDB is assumed to be the source of truth for metadata. All updates to existing metadata should
 be made in the DocDB.
 
 We have automated jobs to keep changes in DocDB, S3, and Code Ocean in sync.
@@ -57,17 +57,12 @@ The workflow is generally as follows:
       sync, update them.
    -  If the metadata.nd.json file is outdated, update it.
 3. Paginate S3 to get all prefixes for a particular bucket.
-4. For each prefix, process by checking if it is a new data asset
+4. For each prefix, process by checking if it is a new derived data asset
    and adding it to DocDB if necessary.
    
-   -  If the metadata record exists in S3 but not in DocDB, copy it
-      to DocDB.
-   -  If the metadata record for a derived asset does not exist in S3,
-      create it and save it to S3. Assume a Lambda function will move it
-      over to DocDB. Metadata records for raw assets are created during
+   -  If the metadata record for a derived asset does not exist in DocDB,
+      register the asset. Raw assets are registered during
       the upload process, **not** by this job.
-   -  In both cases above, ensure the original metadata folder and core
-      files are in sync with the metadata.nd.json file.
 
 Please refer to the job's docstrings for more details on the implementation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "dask==2023.5.0",
     "aind-data-schema==1.2.0",
     "codeocean==0.3.0",
-    "aind-data-access-api>=1.0.0",
+    "aind-data-access-api>=1.6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -8,7 +8,6 @@ import sys
 import warnings
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
-from uuid import uuid4
 
 import boto3
 import dask.bag as dask_bag
@@ -28,14 +27,12 @@ from urllib3.util import Retry
 from aind_data_asset_indexer.models import AindIndexBucketJobSettings
 from aind_data_asset_indexer.utils import (
     build_docdb_location_to_id_map,
-    build_metadata_record_from_prefix,
     compute_md5_hash,
-    cond_copy_then_sync_core_json_files,
     core_schema_file_names,
     create_metadata_object_key,
     create_object_key,
-    does_s3_prefix_exist,
     does_s3_object_exist,
+    does_s3_prefix_exist,
     download_json_file_from_s3,
     get_dict_of_core_schema_file_info,
     get_dict_of_file_info,
@@ -44,7 +41,6 @@ from aind_data_asset_indexer.utils import (
     list_metadata_copies,
     metadata_filename,
     upload_json_str_to_s3,
-    upload_metadata_json_str_to_s3,
 )
 
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
@@ -114,8 +110,7 @@ class AindIndexBucketJob:
         ----------
         s3_client : S3Client
         core_schema_file_name : str
-          For example: 'subject.json', 'procedures.json', etc. Use None to
-          write to metadata_nd_json file.
+          For example: 'subject.json', 'procedures.json', etc.
         core_schema_info_in_root : dict | None
           For example: {'e_tag': ...}. None if no file in root folder.
         prefix : str
@@ -368,7 +363,7 @@ class AindIndexBucketJob:
         1. Check if its location field is valid. If not, log a warning.
         2. Check if it needs to be deleted (no s3 prefix found). If so, the
         record is de-registered from DocDB and Code Ocean.
-        3. If there is an s3 object, then overwrite the s3 object if the docdb
+        3. If there is an s3 prefix, overwrite the .nd.json object if the docdb
         is different. Also resolves the core schema json files in the root
         folder and the original_metadata folder to ensure they are in sync.
 
@@ -445,7 +440,9 @@ class AindIndexBucketJob:
                     )
                     docdb_record = docdb_response[0]
                 # Sync docdb record to metadata.nd.json in root folder
-                metadata_nd_object_key = create_metadata_object_key(prefix=prefix)
+                metadata_nd_object_key = create_metadata_object_key(
+                    prefix=prefix
+                )
                 metadata_nd_json_info = get_dict_of_file_info(
                     s3_client=s3_client,
                     bucket=s3_bucket,
@@ -557,16 +554,12 @@ class AindIndexBucketJob:
     ):
         """
         Processes a prefix in S3
-        1) If metadata record exists in S3 and DocDB, do nothing.
-        2) If record is in S3 but not DocDb, then copy it to DocDb if the
-        location in the metadata record matches the actual location and
-        the record has an _id field. Otherwise, log a warning.
-        3) If record does not exist in both DocDB and S3, check the data level.
-        For derived assets, build a new metadata file and save it to S3 (assume
-        Lambda function will save to DocDB).
-        4) In both cases above, we also copy the original core json files to a
-        subfolder and ensure the top level core jsons are in sync with the
-        metadata.nd.json in S3.
+        1) If metadata record exists in DocDB for this prefix, do nothing.
+        2) If record does not exist in DocDB, check the data level.
+        For derived assets, build a new metadata record and save it to DocDB
+        using the asset registration api (assume next docdb_sync index job
+        will create the .nd.json file and resolve the core files).
+        For non-derived assets, log a warning and do nothing.
 
         Parameters
         ----------
@@ -586,117 +579,31 @@ class AindIndexBucketJob:
             record_id = location_to_id_map.get(location)
         else:
             record_id = None
-        object_key = create_metadata_object_key(prefix=s3_prefix)
-        does_metadata_file_exist = does_s3_object_exist(
-            s3_client=s3_client,
-            bucket=bucket,
-            key=object_key,
-        )
-        if does_metadata_file_exist:
-            # If record not in DocDb, then copy it to DocDb.
-            # If location in the record does not match the actual s3 location,
-            # first log a warning and correct the record.
-            s3_full_location = get_s3_location(bucket, object_key)
-            if record_id is None:
-                json_contents = download_json_file_from_s3(
-                    s3_client=s3_client,
-                    bucket=bucket,
-                    object_key=object_key,
-                )
-                if json_contents:
-                    # noinspection PyTypeChecker
-                    if not is_record_location_valid(
-                        json_contents,
-                        expected_bucket=bucket,
-                        expected_prefix=s3_prefix,
-                    ):
-                        logging.warning(
-                            f"Location field {json_contents.get('location')} "
-                            "does not match actual location of record "
-                            f"{location}! Updating record with correct "
-                            "location and new id."
-                        )
-                        json_contents.update(
-                            {
-                                "_id": str(uuid4()),
-                                "location": location,
-                            }
-                        )
-                    if "_id" in json_contents:
-                        logging.info(f"Adding record to docdb for: {location}")
-                        response = docdb_client.insert_one_docdb_record(
-                            record=json_contents
-                        )
-                        logging.debug(response.json())
-                        cond_copy_then_sync_core_json_files(
-                            metadata_json=json.dumps(
-                                json_contents, default=str
-                            ),
-                            bucket=bucket,
-                            prefix=s3_prefix,
-                            s3_client=s3_client,
-                            copy_original_md_subdir=(
-                                self.job_settings.copy_original_md_subdir
-                            ),
-                        )
-                    else:
-                        logging.warning(
-                            f"Metadata record for {location} "
-                            f"does not have an _id field!"
-                        )
-                else:
-                    logging.warning(
-                        f"Unable to download file from S3 for: "
-                        f"{s3_full_location}!"
-                    )
-            else:
-                logging.info(
-                    f"Metadata record for {s3_full_location} "
-                    f"already exists in DocDb. Skipping."
-                )
+        if record_id is not None:
+            logging.info(
+                f"Metadata record for {location} "
+                f"already exists in DocDb. Skipping."
+            )
         elif (
-            self._get_data_level_for_prefix(
+            record_id is None
+            and self._get_data_level_for_prefix(
                 s3_client=s3_client, bucket=bucket, prefix=s3_prefix
             )
             == DataLevel.DERIVED.value
         ):
-            # Build a new metadata file, save it to S3 and save it to DocDb.
-            # Also copy the original core json files to a subfolder and then
-            # overwrite them with the new fields from metadata.nd.json.
-            new_metadata_contents = build_metadata_record_from_prefix(
-                bucket=bucket,
-                prefix=s3_prefix,
-                s3_client=s3_client,
+            # Register derived asset with no docdb record:
+            # - Creates a record in DocDB based on core files in S3 prefix
+            # - Registers asset to Code Ocean if not already registered
+            # Assume next docdb_sync index job will create the .nd.json file
+            # and copy root files to /original_metadata.
+            logging.info(f"Registering derived asset for: {location}")
+            register_response = docdb_client.register_asset(
+                s3_location=location,
             )
-            if new_metadata_contents is not None:
-                # noinspection PyTypeChecker
-                cond_copy_then_sync_core_json_files(
-                    metadata_json=new_metadata_contents,
-                    bucket=bucket,
-                    prefix=s3_prefix,
-                    s3_client=s3_client,
-                    copy_original_md_subdir=(
-                        self.job_settings.copy_original_md_subdir
-                    ),
-                )
-                logging.info(f"Uploading metadata record for: {location}")
-                # noinspection PyTypeChecker
-                s3_response = upload_metadata_json_str_to_s3(
-                    metadata_json=new_metadata_contents,
-                    bucket=bucket,
-                    prefix=s3_prefix,
-                    s3_client=s3_client,
-                )
-                logging.debug(s3_response)
-                # Assume Lambda function will move it to DocDb. If it doesn't,
-                # then next index job will pick it up.
-            else:
-                logging.warning(
-                    f"Unable to build metadata record for: {location}!"
-                )
+            logging.info(register_response)
         else:
-            logging.info(
-                f"Metadata record for {location} not found in S3 and data "
+            logging.warning(
+                f"Metadata record for {location} not found in DocDB but data "
                 "level is not derived. Skipping."
             )
 

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -54,21 +54,16 @@ class AindIndexBucketJob:
     not have valid location, it will log a warning and not process it further.
     2.0) For each record, check if the S3 location exists. If the S3 location
     does not exist, then remove the record from DocDB.
-    2.1) If the S3 location exists, check if there is a metadata.nd.json file.
-    2.1.0) If there is no file, log a warning and remove the record from DocDb.
-    2.1.1) If there is a file, resolve the core schema json files in the root
-    folder and the original_metadata folder to ensure they are in sync.
-    2.1.2) Then compare the md5 hashes. If they are different, overwrite the
+    2.1) If the S3 location exists, resolve the core schema json files in the
+    root folder and the original_metadata folder to ensure they are in sync.
+    2.1.1) Then compare the md5 hashes. If they are different, overwrite the
     record in S3 with the record from DocDb. Otherwise, do nothing.
     3) Scan through each prefix in S3.
-    4) For each prefix, check if a metadata record exists in S3.
-    4.0) If a metadata record exists, check if it is in DocDB.
+    4) For each prefix, check if it is in DocDB.
     4.1) If already in DocDb, then don't do anything.
-    Otherwise, copy record to DocDB.
     4.2) If a metadata record does not exist and the asset is derived, then
-    build and save it to S3. Assume a lambda function will move it to DocDB.
-    4.3) In both cases above, ensure the original metadata folder and core
-    files are in sync with the metadata.nd.json file.
+    register it to DocDB. Assume a subsequent docdb sync job will resolve the
+    original metadata folder and core files as in step 2.1.
     """
 
     def __init__(self, job_settings: AindIndexBucketJobSettings):

--- a/src/aind_data_asset_indexer/aind_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/aind_bucket_indexer.py
@@ -387,7 +387,7 @@ class AindIndexBucketJob:
             if not does_prefix_exist:
                 logging.warning(
                     f"Asset not found in S3 at {docdb_record['location']}! "
-                    f"Deleting metadata record from DocDb and Code Ocean."
+                    "Deleting metadata record from DocDb and Code Ocean."
                 )
                 response = docdb_client.deregister_asset(
                     s3_location=docdb_record["location"],
@@ -598,7 +598,7 @@ class AindIndexBucketJob:
             logging.info(register_response)
         else:
             logging.warning(
-                f"Metadata record for {location} not found in DocDB but data "
+                f"Metadata record for {location} not found in DocDB and data "
                 "level is not derived. Skipping."
             )
 

--- a/src/aind_data_asset_indexer/utils.py
+++ b/src/aind_data_asset_indexer/utils.py
@@ -269,7 +269,10 @@ def does_s3_object_exist(s3_client: S3Client, bucket: str, key: str) -> bool:
         else:
             raise e
 
-def does_s3_prefix_exist(s3_client: S3Client, bucket: str, prefix: str) -> bool:
+
+def does_s3_prefix_exist(
+    s3_client: S3Client, bucket: str, prefix: str
+) -> bool:
     """
     Check that a prefix exists inside a bucket.
 

--- a/src/aind_data_asset_indexer/utils.py
+++ b/src/aind_data_asset_indexer/utils.py
@@ -269,6 +269,31 @@ def does_s3_object_exist(s3_client: S3Client, bucket: str, key: str) -> bool:
         else:
             raise e
 
+def does_s3_prefix_exist(s3_client: S3Client, bucket: str, prefix: str) -> bool:
+    """
+    Check that a prefix exists inside a bucket.
+
+    Parameters
+    ----------
+    s3_client : S3Client
+    bucket : str
+    prefix : str
+      For example, behavior_655019_2020-10-10_01-00-23
+
+    Returns
+    -------
+    bool
+      True if the prefix exists, otherwise False.
+    """
+    # Use trailing slash and delimiter to get top-level keys in prefix
+    # KeyCount contains count of Contents and CommonPrefixes
+    response = s3_client.list_objects_v2(
+        Bucket=bucket, Prefix=prefix.strip("/") + "/", Delimiter="/"
+    )
+    if response.get("KeyCount") and response["KeyCount"] > 0:
+        return True
+    return False
+
 
 def does_s3_metadata_copy_exist(
     s3_client: S3Client, bucket: str, prefix: str, copy_subdir: str

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ from aind_data_asset_indexer.utils import (
     create_object_key,
     does_s3_metadata_copy_exist,
     does_s3_object_exist,
+    does_s3_prefix_exist,
     download_json_file_from_s3,
     get_all_processed_codeocean_asset_records,
     get_dict_of_core_schema_file_info,
@@ -995,7 +996,7 @@ class TestUtils(unittest.TestCase):
                 bucket=bucket,
                 prefix=pfx,
                 s3_client=mock_s3_client,
-                copy_original_md_subdir="original_metadata"
+                copy_original_md_subdir="original_metadata",
             )
         expected_output_messages = [
             f"WARNING:root:Copy of original metadata already exists at "
@@ -1313,6 +1314,40 @@ class TestUtils(unittest.TestCase):
         }
 
         self.assertEqual(expected_records, records)
+
+    @patch("boto3.client")
+    def test_does_s3_prefix_exist_true(self, mock_s3_client: MagicMock):
+        """Tests does_s3_prefix_exist when true"""
+        mock_s3_client.list_objects_v2.return_value = (
+            self.example_list_objects_response
+        )
+        result = does_s3_prefix_exist(
+            bucket="bucket",
+            prefix="prefix",
+            s3_client=mock_s3_client,
+        )
+        self.assertTrue(result)
+        mock_s3_client.list_objects_v2.assert_called_once_with(
+            Bucket="bucket",
+            Prefix="prefix/",
+            Delimiter="/",
+        )
+
+    @patch("boto3.client")
+    def test_does_s3_prefix_exist_false(self, mock_s3_client: MagicMock):
+        """Tests does_s3_prefix_exist when false"""
+        mock_s3_client.list_objects_v2.return_value = (
+            self.example_list_objects_response_false
+        )
+        result = does_s3_prefix_exist(
+            bucket="bucket",
+            prefix="prefix",
+            s3_client=mock_s3_client,
+        )
+        mock_s3_client.list_objects_v2.assert_called_once_with(
+            Bucket="bucket", Prefix="prefix/", Delimiter="/"
+        )
+        self.assertFalse(result)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1337,7 +1337,7 @@ class TestUtils(unittest.TestCase):
     def test_does_s3_prefix_exist_false(self, mock_s3_client: MagicMock):
         """Tests does_s3_prefix_exist when false"""
         mock_s3_client.list_objects_v2.return_value = (
-            self.example_list_objects_response_false
+            self.example_list_objects_response_none
         )
         result = does_s3_prefix_exist(
             bucket="bucket",


### PR DESCRIPTION
closes #161

This PR updates the AindIndexBucketJob to use the new /register and /deregister endpoints:
- upgrade aind-data-access-api to 1.6.0
- removes dependency on .nd.json files
- delete docdb assets using /deregister endpoint
- auto-register derived assets in AIND-managed buckets using /register endpoint
- update User Guide and docstrings with new workflow

Deployment- indexer ECS task needs permission to invoke the registration endpoints
