### PR TITLE
fix: error handling for invalid external_links format

### DIFF
--- a/src/aind_data_asset_indexer/codeocean_bucket_indexer.py
+++ b/src/aind_data_asset_indexer/codeocean_bucket_indexer.py
@@ -218,37 +218,45 @@ class CodeOceanIndexBucketJob:
             for page in pages:
                 records_to_update = []
                 for record in page:
-                    location = record.get("location")
-                    external_links = self._get_co_links_from_record(record)
-                    code_ocean_ids = (
-                        None
-                        if location is None
-                        else co_loc_to_id_map.get(location)
-                    )
-                    docdb_rec_id = record["_id"]
-                    if code_ocean_ids is not None and code_ocean_ids != set(
-                        external_links
-                    ):
-                        new_external_links = code_ocean_ids
-                    elif external_links and not code_ocean_ids:
-                        logging.info(
-                            f"No code ocean data asset ids found for "
-                            f"{location}. Removing external links from record."
+                    try:
+                        location = record.get("location")
+                        external_links = self._get_co_links_from_record(record)
+                        code_ocean_ids = (
+                            None
+                            if location is None
+                            else co_loc_to_id_map.get(location)
                         )
-                        new_external_links = set()
-                    else:
-                        new_external_links = None
-                    if new_external_links is not None:
-                        record_links = {
-                            ExternalPlatforms.CODEOCEAN.value: sorted(
-                                list(new_external_links)
+                        docdb_rec_id = record["_id"]
+                        if (
+                            code_ocean_ids is not None
+                            and code_ocean_ids != set(external_links)
+                        ):
+                            new_external_links = code_ocean_ids
+                        elif external_links and not code_ocean_ids:
+                            logging.info(
+                                f"No code ocean data asset ids found for "
+                                f"{location}. Removing external links from "
+                                "record."
                             )
-                        }
-                        records_to_update.append(
-                            {
-                                "_id": docdb_rec_id,
-                                "external_links": record_links,
+                            new_external_links = set()
+                        else:
+                            new_external_links = None
+                        if new_external_links is not None:
+                            record_links = {
+                                ExternalPlatforms.CODEOCEAN.value: sorted(
+                                    list(new_external_links)
+                                )
                             }
+                            records_to_update.append(
+                                {
+                                    "_id": docdb_rec_id,
+                                    "external_links": record_links,
+                                }
+                            )
+                    except Exception as e:
+                        logging.error(
+                            f'Error processing {record.get("location")}: '
+                            f"{repr(e)}"
                         )
                 if len(records_to_update) > 0:
                     logging.info(f"Updating {len(records_to_update)} records")

--- a/tests/test_codeocean_bucket_indexer.py
+++ b/tests/test_codeocean_bucket_indexer.py
@@ -288,6 +288,11 @@ class TestCodeOceanIndexBucketJob(unittest.TestCase):
                     "location": "s3://bucket2/prefix4",
                     "external_links": [],
                 },
+                {
+                    "_id": "0004",
+                    "location": "s3://bucket3/prefix5",
+                    "external_links": ["def-456"],
+                },
             ]
         ]
 
@@ -299,6 +304,10 @@ class TestCodeOceanIndexBucketJob(unittest.TestCase):
         expected_log_messages = [
             "INFO:root:No code ocean data asset ids found for "
             "s3://bucket2/prefix3. Removing external links from record.",
+            "ERROR:root:Error processing s3://bucket3/prefix5: "
+            "ValueError(\"Invalid external_links for: {'_id': '0004', "
+            "'location': 's3://bucket3/prefix5', 'external_links': "
+            "['def-456']}\")",
             "INFO:root:Updating 2 records",
             f"DEBUG:root:[{bulk_write_response}]",
         ]


### PR DESCRIPTION
fixes #174 

Checks `external_links` to ensure it matches current or legacy format. Invalid records are logged but index job will continue to process other records.